### PR TITLE
#137-Temp hack fix for Opencalais

### DIFF
--- a/inc/class.admin.suggest.php
+++ b/inc/class.admin.suggest.php
@@ -155,7 +155,7 @@ class SimpleTags_Admin_Suggest {
 			exit();
 		}
 
-		$response = wp_remote_post( 'https://api.thomsonreuters.com/permid/calais', array(
+		$response = wp_remote_post( 'https://api-eit.refinitiv.com/permid/calais', array(
 			'timeout' => 30,
 			'headers' => array(
 				'X-AG-Access-Token' => SimpleTags_Plugin::get_option_value( 'opencalais_key' ),


### PR DESCRIPTION
Updated API URL for opencalais from https://api.thomsonreuters.com/permid/calais to https://api-eit.refinitiv.com/permid/calais

Tested on my live server, it works although like before Refinitiv adds some odd Draft:XXX curve balls!