### PR TITLE
feature/#146-use-one-admin-menu-link-taxopress

### DIFF
--- a/inc/class.admin.autoterms.php
+++ b/inc/class.admin.autoterms.php
@@ -1,14 +1,17 @@
 <?php
 
 class SimpleTags_Admin_AutoTags {
+
+	const MENU_SLUG = 'st_options';
+
 	// Build admin URL
-	static $tools_base_url = '';
+	static $admin_base_url = '';
 
 	/**
 	 * SimpleTags_Admin_AutoTags constructor.
 	 */
 	public function __construct() {
-		self::$tools_base_url = admin_url( 'tools.php' ) . '?page=';
+		self::$admin_base_url = admin_url( 'admin.php' ) . '?page=';
 
 		// Admin menu
 		add_action( 'admin_menu', array( __CLASS__, 'admin_menu' ) );
@@ -24,10 +27,17 @@ class SimpleTags_Admin_AutoTags {
 	 * @author Amaury Balmer
 	 */
 	public static function admin_menu() {
-		add_management_page( __( 'Simple Terms: Auto Terms', 'simpletags' ), __( 'Auto Terms', 'simpletags' ), 'simple_tags', 'st_auto', array(
-			__CLASS__,
-			'pageAutoTerms'
-		) );
+		add_submenu_page(
+			self::MENU_SLUG,
+			__( 'Simple Terms: Auto Terms', 'simpletags' ),
+			__( 'Auto Terms', 'simpletags' ),
+			'simple_tags',
+			'st_auto',
+			array(
+				__CLASS__,
+				'pageAutoTerms',
+			)
+		);
 	}
 
 	/**
@@ -169,9 +179,9 @@ class SimpleTags_Admin_AutoTags {
 								echo '<td>' . "\n";
 								if ( in_array( $line_taxo->name, $compatible_taxonomies ) ) {
 									if ( isset( $options[ $post_type->name ][ $line_taxo->name ] ) && isset( $options[ $post_type->name ][ $line_taxo->name ]['use_auto_terms'] ) && $options[ $post_type->name ][ $line_taxo->name ]['use_auto_terms'] == '1' ) {
-										echo '<a href="' . self::$tools_base_url . 'st_auto&taxo=' . $line_taxo->name . '&cpt=' . $post_type->name . '"><img src="' . STAGS_URL . '/assets/images/lightbulb.png" alt="' . __( 'Context configured & actived.', 'simpletags' ) . '" /></a>' . "\n";
+										echo '<a href="' . self::$admin_base_url . 'st_auto&taxo=' . $line_taxo->name . '&cpt=' . $post_type->name . '"><img src="' . STAGS_URL . '/assets/images/lightbulb.png" alt="' . __( 'Context configured & actived.', 'simpletags' ) . '" /></a>' . "\n";
 									} else {
-										echo '<a href="' . self::$tools_base_url . 'st_auto&taxo=' . $line_taxo->name . '&cpt=' . $post_type->name . '"><img src="' . STAGS_URL . '/assets/images/lightbulb_off.png" alt="' . __( 'Context unconfigured.', 'simpletags' ) . '" /></a>' . "\n";
+										echo '<a href="' . self::$admin_base_url . 'st_auto&taxo=' . $line_taxo->name . '&cpt=' . $post_type->name . '"><img src="' . STAGS_URL . '/assets/images/lightbulb_off.png" alt="' . __( 'Context unconfigured.', 'simpletags' ) . '" /></a>' . "\n";
 									}
 								} else {
 									echo '-' . "\n";
@@ -197,7 +207,7 @@ class SimpleTags_Admin_AutoTags {
 
 				<h3><?php _e( 'Options', 'simpletags' ); ?></h3>
 				<form
-					action="<?php echo self::$tools_base_url . 'st_auto&taxo=' . SimpleTags_Admin::$taxonomy . '&cpt=' . SimpleTags_Admin::$post_type; ?>"
+					action="<?php echo self::$admin_base_url . 'st_auto&taxo=' . SimpleTags_Admin::$taxonomy . '&cpt=' . SimpleTags_Admin::$post_type; ?>"
 					method="post">
 					<table class="form-table">
 						<tr valign="top">
@@ -268,7 +278,7 @@ class SimpleTags_Admin_AutoTags {
 				</p>
 				<p class="submit">
 					<a class="button-primary"
-					   href="<?php echo self::$tools_base_url . 'st_auto&amp;taxo=' . SimpleTags_Admin::$taxonomy . '&amp;cpt=' . SimpleTags_Admin::$post_type . '&amp;action=auto_tag'; ?>"><?php _e( 'Auto terms all content &raquo;', 'simpletags' ); ?></a>
+					   href="<?php echo self::$admin_base_url . 'st_auto&amp;taxo=' . SimpleTags_Admin::$taxonomy . '&amp;cpt=' . SimpleTags_Admin::$post_type . '&amp;action=auto_tag'; ?>"><?php _e( 'Auto terms all content &raquo;', 'simpletags' ); ?></a>
 				</p>
 
 			<?php else:
@@ -292,12 +302,12 @@ class SimpleTags_Admin_AutoTags {
 			echo '</ul>';
 			?>
 				<p><?php _e( "If your browser doesn't start loading the next page automatically click this link:", 'simpletags' ); ?>
-					<a href="<?php echo self::$tools_base_url . 'st_auto&amp;taxo=' . SimpleTags_Admin::$taxonomy . '&amp;cpt=' . SimpleTags_Admin::$post_type . '&amp;action=auto_tag&amp;n=' . ( $n + 20 ); ?>"><?php _e( 'Next content', 'simpletags' ); ?></a>
+					<a href="<?php echo self::$admin_base_url . 'st_auto&amp;taxo=' . SimpleTags_Admin::$taxonomy . '&amp;cpt=' . SimpleTags_Admin::$post_type . '&amp;action=auto_tag&amp;n=' . ( $n + 20 ); ?>"><?php _e( 'Next content', 'simpletags' ); ?></a>
 				</p>
 				<script type="text/javascript">
 					// <![CDATA[
 					function nextPage() {
-						location.href = "<?php echo self::$tools_base_url.'st_auto&taxo='.SimpleTags_Admin::$taxonomy.'&cpt='.SimpleTags_Admin::$post_type.'&action=auto_tag&n='.($n + 20); ?>";
+						location.href = "<?php echo self::$admin_base_url.'st_auto&taxo='.SimpleTags_Admin::$taxonomy.'&cpt='.SimpleTags_Admin::$post_type.'&action=auto_tag&n='.($n + 20); ?>";
 					}
 					window.setTimeout('nextPage()', 300);
 					// ]]>

--- a/inc/class.admin.manage.php
+++ b/inc/class.admin.manage.php
@@ -1,6 +1,9 @@
 <?php
 
 class SimpleTags_Admin_Manage {
+
+	const MENU_SLUG = 'st_options';
+	
 	/**
 	 * Constructor
 	 *
@@ -40,10 +43,17 @@ class SimpleTags_Admin_Manage {
 	 * @author Amaury Balmer
 	 */
 	public static function admin_menu() {
-		add_management_page( __( 'Simple Terms: Manage Terms', 'simpletags' ), __( 'Manage Terms', 'simpletags' ), 'simple_tags', 'st_manage', array(
-			__CLASS__,
-			'page_manage_tags'
-		) );
+		add_submenu_page(
+			self::MENU_SLUG,
+			__( 'Simple Terms: Manage Terms', 'simpletags' ),
+			__( 'Manage Terms', 'simpletags' ),
+			'simple_tags',
+			'st_manage',
+			array(
+				__CLASS__,
+				'page_manage_tags',
+			)
+		); 
 	}
 
 	/**

--- a/inc/class.admin.mass.php
+++ b/inc/class.admin.mass.php
@@ -2,6 +2,8 @@
 
 class SimpleTags_Admin_Mass {
 
+	const MENU_SLUG = 'st_options';
+
 	/**
 	 * SimpleTags_Admin_Mass constructor.
 	 */
@@ -23,10 +25,18 @@ class SimpleTags_Admin_Mass {
 	 * @author Amaury Balmer
 	 */
 	public static function admin_menu() {
-		add_management_page( __( 'Simple Terms: Mass Edit Terms', 'simpletags' ), __( 'Mass Edit Terms', 'simpletags' ), 'simple_tags', 'st_mass_terms', array(
-			__CLASS__,
-			'pageMassEditTags',
-		) );
+
+		add_submenu_page(
+			self::MENU_SLUG,
+			__( 'Simple Terms: Mass Edit Terms', 'simpletags' ),
+			__( 'Mass Edit Terms', 'simpletags' ),
+			'simple_tags',
+			'st_mass_terms',
+			array(
+				__CLASS__,
+				'pageMassEditTags',
+			)
+		); 
 	}
 
 	/**
@@ -110,7 +120,7 @@ class SimpleTags_Admin_Mass {
 					$status_links   = array();
 					$num_posts      = wp_count_posts( SimpleTags_Admin::$post_type, 'readable' );
 					$class          = ( empty( $_GET['post_status'] ) && empty( $_GET['post_type'] ) ) ? ' class="current"' : '';
-					$status_links[] = '<li><a href="' . admin_url( 'tools.php' ) . '?page=st_mass_terms&amp;cpt=' . SimpleTags_Admin::$post_type . '&amp;taxo=' . SimpleTags_Admin::$taxonomy . '"' . $class . '>' . __( 'All', 'simpletags' ) . '</a>';
+					$status_links[] = '<li><a href="' . admin_url( 'admin.php' ) . '?page=st_mass_terms&amp;cpt=' . SimpleTags_Admin::$post_type . '&amp;taxo=' . SimpleTags_Admin::$taxonomy . '"' . $class . '>' . __( 'All', 'simpletags' ) . '</a>';
 					foreach ( $post_stati as $status => $label ) {
 						$class = '';
 
@@ -125,7 +135,7 @@ class SimpleTags_Admin_Mass {
 							$class = ' class="current"';
 						}
 
-						$status_links[] = '<li><a href="' . admin_url( 'tools.php' ) . '?page=st_mass_terms&amp;cpt=' . SimpleTags_Admin::$post_type . '&amp;taxo=' . SimpleTags_Admin::$taxonomy . '&amp;post_status=' . $status . '"' . $class . '>' . sprintf( _n( $label[2][0], $label[2][1], (int) $num_posts->$status ), number_format_i18n( $num_posts->$status ) ) . '</a>';
+						$status_links[] = '<li><a href="' . admin_url( 'admin.php' ) . '?page=st_mass_terms&amp;cpt=' . SimpleTags_Admin::$post_type . '&amp;taxo=' . SimpleTags_Admin::$taxonomy . '&amp;post_status=' . $status . '"' . $class . '>' . sprintf( _n( $label[2][0], $label[2][1], (int) $num_posts->$status ), number_format_i18n( $num_posts->$status ) ) . '</a>';
 					}
 					echo implode( ' |</li>', $status_links ) . '</li>';
 					unset( $status_links );

--- a/inc/class.admin.php
+++ b/inc/class.admin.php
@@ -357,7 +357,10 @@ class SimpleTags_Admin {
 	 * @author Amaury Balmer
 	 */
 	public static function admin_menu() {
-		add_options_page(
+
+		self::$admin_url = admin_url( 'admin.php?page=' . self::MENU_SLUG );
+
+		add_menu_page(
 			__( 'TaxoPress: Options', 'simpletags' ),
 			__( 'TaxoPress', 'simpletags' ),
 			'admin_simple_tags',
@@ -365,9 +368,10 @@ class SimpleTags_Admin {
 			array(
 				__CLASS__,
 				'page_options',
-			)
+			),
+			'dashicons-tag',
+			69.999
 		);
-		self::$admin_url = admin_url( '/options-general.php?page=' . self::MENU_SLUG );
 	}
 
 	/**


### PR DESCRIPTION
All taxopress menus are now under one parent menu
![taxopress-menu](https://user-images.githubusercontent.com/46832636/108344524-85b6e880-71dd-11eb-97b5-8cb234d57c09.png)
