### PR TITLE
feature/#143-tags-gets-split-when-having-an-amp-in-name

### DIFF
--- a/assets/js/helper-add-tags.js
+++ b/assets/js/helper-add-tags.js
@@ -34,10 +34,13 @@ function addTag (tag) {
     var tag_rest_base = tags_taxonomy && tags_taxonomy.rest_base
     var tags = tag_rest_base && wp.data.select('core/editor').getEditedPostAttribute(tag_rest_base)
 
-    var newTags = JSON.parse(JSON.stringify(tags))
+    //clean tag of & to enable sending in ajax parameter
+    tag = tag.replace('&amp;', 'simpletagand');
 
+    var newTags = JSON.parse(JSON.stringify(tags));
+    
     jQuery.ajax({
-      url: ajaxurl + '?action=simpletags&stags_action=maybe_create_tag&tag=' + tag,
+      url: ajaxurl + '?action=simpletags&stags_action=maybe_create_tag&tag=' + ""+tag+"",
       cache: false,
       //async: false,
       dataType: 'json'

--- a/inc/class.admin.php
+++ b/inc/class.admin.php
@@ -85,6 +85,8 @@ class SimpleTags_Admin {
 	 */
 	public static function maybe_create_tag( $tag_name = '' ) {
 		$term_id     = 0;
+		//restore & in tag post 
+		$tag_name = str_replace("simpletagand", "&", $tag_name);
 		$result_term = term_exists( $tag_name, 'post_tag', 0 );
 		if ( empty( $result_term ) ) {
 			$result_term = wp_insert_term(


### PR DESCRIPTION
[FIX] - #143 Tags gets split when having an ‘&’ Ampersand in name