### PR TITLE
feature/update-firefox-width-for-terms-page 

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -24,6 +24,7 @@
 .st_wrap input.tags_input{width:90%;margin:3px 0 8px;padding:3px 10px;}
 .st-mass-edit input.tags_input{
   width: -webkit-fill-available !important;
+  width: -moz-available !important;
 }
 
 /* Suggested Click Tags   */
@@ -191,6 +192,7 @@ a#close_clicktags{display:none;}
 }
 .taxopress_page_st_terms_display .shortcode.column-shortcode input[type=text] {
     width: -webkit-fill-available;
+    width: -moz-available;
 }
 .taxopress_page_st_terms_display #col-container,
 .taxopress_page_st_post_tags #col-container,
@@ -203,6 +205,7 @@ a#close_clicktags{display:none;}
 }
 .taxopress_page_st_post_tags .shortcode.column-shortcode input[type=text] {
     width: -webkit-fill-available;
+    width: -moz-available;
 }
 
 .taxopress_page_st_post_tags .manage-column.column-embedded {
@@ -211,16 +214,17 @@ a#close_clicktags{display:none;}
 
 .st-full-width {
     width: -webkit-fill-available !important;
+    width: -moz-available !important;
 }
 .tagcloudui {
-    width: calc(100% - 300px);
+    width: calc(100% - 350px);
     display: inline-block;
 }
 .taxopress-right-sidebar {
     float: right;
     margin-left: 20px;
     margin-top: 10px;
-    width: 275px;
+    width: 325px;
 }
 .taxopress-right-sidebar-wrapper {
     background: #fff;
@@ -273,7 +277,10 @@ font-weight: bold;
     color: #2271b1;
     cursor: pointer;
 }
-
+.taxopress-warning textarea {
+    width: -webkit-fill-available !important;
+    width: -moz-available !important;
+}
 @media only screen and (max-width: 1270px) {
     .tagcloudui,
     .taxopress-right-sidebar {

--- a/assets/css/taxonomies.css
+++ b/assets/css/taxonomies.css
@@ -2,7 +2,7 @@
     margin-left: 8px;
 }
 .posttypesui, .taxonomiesui {
-    width: calc(100% - 300px);
+    width: calc(100% - 350px);
 }
 
 .posttypesui .taxopress-section:first-child, .taxonomiesui .taxopress-section:first-child {
@@ -282,7 +282,7 @@ fieldset .taxopress-help {
     float: right;
     margin-left: 20px;
     margin-top: 10px;
-    width: 275px;
+    width: 325px;
 }
 
 .taxopress-right-sidebar-about {
@@ -527,5 +527,6 @@ ul.st-taxonomy-tab li.active a {
         float: none;
         margin: initial;
         width: -webkit-fill-available;
+        width: -moz-available;
     }
 }


### PR DESCRIPTION
- Boxes are too long under "Mass Edit Terms" close #564

- Increase width of Term Link boxes close #562

- Wider sidebar close #561