### PR TITLE
feature/#575-Keywords_list_is_always_added_even_when_the_option_is_unchecked_in_Auto_Terms

### DIFF
--- a/inc/class.client.autoterms.php
+++ b/inc/class.client.autoterms.php
@@ -96,7 +96,7 @@ class SimpleTags_Client_Autoterms {
 		}
 
 		// Auto term with specific auto terms list
-		if ( isset( $options['auto_list'] ) ) {
+		if ( isset( $options['auto_list'] ) && isset( $options['at_all_no'] ) && $options['at_all_no'] == 1 ) {
 			$terms = (array) maybe_unserialize( $options['auto_list'] );
 			foreach ( $terms as $term ) {
 				if ( ! is_string( $term ) ) {


### PR DESCRIPTION
- 'Keywords list' is always added even when the option is unchecked in Auto Terms close #575