### PR TITLE
feature/#610-Can_remove_terms_from_posts_that_container_just_letters_or_a_mix_of_numbers_and_letters_but_wont_if_the_term_is_straight_numbers

### DIFF
--- a/inc/class.admin.manage.php
+++ b/inc/class.admin.manage.php
@@ -655,6 +655,13 @@ class SimpleTags_Admin_Manage {
         $counter = 0;
         if ( count($new_terms) > 0 ) {
 			foreach ( (array) $new_terms as $term ) {
+                $term = get_term_by('name', $term, $taxonomy);
+                if( empty($term) || !is_object($term) ){
+                    continue;
+                }
+
+                $term = $term->term_id;
+
             $args = array(
                 'post_type' => $post_type, // post_type
                 'posts_per_page' => -1,

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,9 @@ TaxoPress can be installed in 3 easy steps:
 
 == Changelog ==
 
+v3.1.0- 2021-07-01
+* Fixed: Manage terms 'remove terms' not working when term is number only #610
+
 v3.0.7.2- 2021-06-29
 * Added: Add taxonomy privacy filter to taxonomy screen #599
 * Fixed: Fixed bugs


### PR DESCRIPTION
- Manage terms 'remove terms' not working when term is number only close #610