### PR TITLE
feature/#644-Issues_with_WordPress_5.8

### DIFF
--- a/blocks/related-posts.php
+++ b/blocks/related-posts.php
@@ -5,8 +5,13 @@
  */
 function st_related_posts_block_init()
 {
+    global $post, $pagenow;
 
     if (!function_exists('register_block_type')) {
+        return;
+    }
+
+    if($pagenow === 'widgets.php'){
         return;
     }
 

--- a/blocks/src/related-posts.js
+++ b/blocks/src/related-posts.js
@@ -1,4 +1,5 @@
-var el = wp.element.createElement,
+(function (wp) {
+  var el = wp.element.createElement,
   registerBlockType = wp.blocks.registerBlockType,
   ServerSideRender = wp.components.ServerSideRender,
   TextControl = wp.components.TextControl,
@@ -41,3 +42,7 @@ registerBlockType('taxopress/related-posts', {
     return null
   },
 })
+
+} )(
+	window.wp
+);

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,9 @@ TaxoPress can be installed in 3 easy steps:
 
 == Changelog ==
 
+v3.1.1- [===UNRELEASED==]
+* Fixed: TaxoPress related posts block block compatibility with WordPress 5.8 #644
+
 v3.1.0- 2021-07-12
 * Added: Add Related Posts screen #491
 * Added: Add Related Posts widget #264


### PR DESCRIPTION
-  Fixed: TaxoPress related posts block block compatibility with WordPress 5.8 close #644

Solution: Related posts block expect a global $post which is not available in widget and since this is required to display related post. So, the block is removed from widget screen.