### PR TITLE
feature/#660-Taxonomy_still_remain_attached_to_a_post_type_after_deselecting_it

### DIFF
--- a/inc/taxonomies-functions.php
+++ b/inc/taxonomies-functions.php
@@ -335,7 +335,13 @@ function taxopress_update_taxonomy($data = [])
         $meta_box_cb = $maybe_false;
     }
 
-    if (!isset($data['taxonomy_external_edit'])) {
+    $internal_taxonomy_edit = true;
+
+    if ( isset($data['taxonomy_external_edit']) || $name === 'media_tag' ) {
+        $internal_taxonomy_edit = false;
+    }
+
+    if ($internal_taxonomy_edit) {
 
         $taxonomies[$data['cpt_custom_tax']['name']] = [
             'name'                  => $name,

--- a/readme.txt
+++ b/readme.txt
@@ -116,7 +116,8 @@ v3.1.1- [===UNRELEASED==]
 * Fixed: TaxoPress related posts block block compatibility with WordPress 5.8 #644
 * Fixed: Related posts shortcode not working in Gutenberg #646
 * Fixed: Undefined array key notice when 'Automatically fill colors between maximum and minimum' is unchecked in Terms Display edit #642
-* Fixed: Taxopress number input accepting negative value #658
+* Fixed: TaxoPress number input accepting negative value #658
+* Fixed: Media tag taxonomy still remain attached to a post type after deselecting it #660
 
 v3.1.0- 2021-07-12
 * Added: Add Related Posts screen #491


### PR DESCRIPTION
-  Fixed: Media tag taxonomy still remain attached to a post type after deselecting it close #660