### PR TITLE
feature/#645-Auto_link_tab_is_not_disabled_after_resetting_the_options_in_Taxopress_settings

### DIFF
--- a/views/admin/page-settings.php
+++ b/views/admin/page-settings.php
@@ -15,7 +15,7 @@
 			}
 
 			// Deactive tabs if feature not actived
-			if ( isset( $options['auto_link_tags'] ) && (int) $options['auto_link_tags'] == 0 && $key == 'auto-links' ) {
+			if ( isset( $options['auto_link_tags'] ) && ( (int) $options['auto_link_tags'] == 0 || (int) SimpleTags_Plugin::get_option_value( 'auto_link_tags' ) === 0 )&& $key == 'auto-links' ) {
 				$style = 'style="display:none;"';
 			}
 


### PR DESCRIPTION
- "Auto link" tab is not disabled after resetting the options in Taxopress settings. close #645