### PR TITLE
#633 Tags in the post are auto linked even if "Auto link all tags" is unchecked.

### DIFF
--- a/inc/helper.options.admin.php
+++ b/inc/helper.options.admin.php
@@ -108,13 +108,13 @@ return array(
             'small-text',
             __('This setting determines the maximum number of links created by article for the same tag. Default: 1.', 'simpletags')
         ),
-        array(
-            'auto_link_all',
-            __('Auto link all tags ?', 'simpletags'),
-            'checkbox',
-            '1',
-            __('If checked, tags found in post will be auto linked even if not included in post tags.', 'simpletags')
-        ),
+	    array(
+		    'auto_link_all',
+		    __('Add links for unattached terms', 'simpletags'),
+		    'checkbox',
+		    '1',
+		    __('By default, TaxoPress will only add Auto Links for terms that are attached to the post. If this box is checked, TaxoPress will add links for all terms', 'simpletags')
+	    ),
         array(
             'auto_link_case',
             __('Ignore case for auto link feature ?', 'simpletags'),


### PR DESCRIPTION
Change text and description as your request:
![image](https://user-images.githubusercontent.com/6948022/127085518-2298007a-b337-4411-a7d0-31b8f3459aa3.png)

Result: 
![image](https://user-images.githubusercontent.com/6948022/127085480-ee6926ee-f62a-452a-b379-f1521635f77b.png)

Thanks.