### PR TITLE
feature/#501-autolinks-screen

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,5 +1,5 @@
 /* Footer admin   */
-.footer_st{text-align:center;font-size:14px;}
+.footer_st{text-align:center;font-size:14px !important;}
 
 /* Block taxonomy  */
 .box-selector-taxonomy{border:1px solid;color:#9F6000;background-color:#FEEFB3;margin:10px 0 0;padding:15px 10px;}
@@ -321,7 +321,135 @@ select#stb-related-post-select {
     background: #1F48AC !important;
 }
 
+.taxopress-help-tooltip {
+    display:inline-block;
+    position:relative;
+    text-align:left;
+    margin-left: 6px;
+    opacity: inherit;
+    border-bottom: 1px dotted #424242;
+}
+
+.taxopress-help-tooltip .tooltip-text {
+    min-width:200px;
+    max-width:400px;
+    margin-left:30px;
+    transform:translate(0, -50%);
+    padding:20px;
+    color:#FFFFFF;
+    background-color: #555;
+    font-weight:normal;
+    font-size:13px;
+    border-radius:8px;
+    position:absolute;
+    z-index:99999999;
+    box-sizing:border-box;
+    display:none;
+    border:1px solid #DCA;
+}
+
+.taxopress-help-tooltip:hover .tooltip-text {
+    display:block;
+}
+
+.taxopress-help-tooltip:before  {
+    color: #424242;
+    opacity: 0.5;
+    text-decoration: none;
+    width: 16px;
+}
+fieldset .taxopress-help-tooltip  {
+    position: relative;
+    top: 4px;
+}
+.taxopress-help-tooltip :hover {
+    color: #0074a2;
+    opacity: 1;
+}
+.taxopress-help-tooltip :focus {
+    box-shadow: none;
+}
+
+ul.taxopress-tab {
+    margin: 0;
+    width: 20%;
+    float: left;
+    line-height: 1em;
+    padding: 0 0 10px;
+    position: relative;
+    background-color: #fafafa;
+    border-right: 1px solid #eee;
+    box-sizing: border-box;
+}
+.taxopress-tab-content {
+    float: left;
+    width: 80%;
+    min-height: 275px;
+    box-sizing: border-box;
+    padding-left: 10px;
+}
+ul.taxopress-tab li {
+    margin: 0;
+    padding: 0;
+    display: block;
+    position: relative;
+}
+ul.taxopress-tab li a {
+    margin: 0;
+    padding: 10px;
+    display: block;
+    box-shadow: none;
+    text-decoration: none;
+    line-height: 20px!important;
+    border-bottom: 1px solid #eee;
+}
+
+ul.taxopress-tab li a::before {
+    font-family: Dashicons;
+    font-weight: 400;
+    text-transform: none;
+    line-height: 1;
+    -webkit-font-smoothing: antialiased;
+    content: "";
+    font-variant: normal;
+    text-decoration: none;
+}
+
+
+ul.taxopress-tab li a span {
+    margin-left: .618em;
+    margin-right: .618em;
+}
+ul.taxopress-tab li.active a {
+    color: #555;
+    position: relative;
+    background-color: #eee;
+}
+
+.st-tabbed #poststuff .inside {
+    margin-left: 0 !important;
+    margin-top: 0 !important;
+    padding-left: 0 !important;
+}
+
+ul.taxopress-tab li.autolink_advanced_tab a::before {
+    content: "\f111";
+}
+ul.taxopress-tab li.autolink_exceptions_tab a::before {
+    content: "\f211";
+}
+ul.taxopress-tab li.autolink_display_tab a::before {
+    content: "\f186";
+}
+ul.taxopress-tab li.autolink_general_tab a::before {
+    content: "\f107";
+}
+ul.taxopress-tab li.autolink_control_tab a::before {
+    content: "\f169";
+}
+
 @media only screen and (max-width: 1270px) {
+
     .tagcloudui,
     .taxopress-right-sidebar {
         display: block;

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -206,7 +206,30 @@
     // -------------------------------------------------------------
     $('.taxopress-right-sidebar input[type="submit"], .taxonomiesui input[type="submit"]').on('click', function (e) {
       $('.taxopress-edit #message.updated').remove();
-    })
+    });
+
+
+    // -------------------------------------------------------------
+    //   Taxopress tab
+    // -------------------------------------------------------------
+    $('ul.taxopress-tab li').on('click', function (e) {
+      e.preventDefault();
+      var tab_content = $(this).attr('data-content');
+      
+      $('.taxopress-tab li').removeClass('active');
+      $(this).addClass('active');
+
+      $('.taxopress-tab-content table').hide();
+      $('.taxopress-tab-content table.' + tab_content).show();
+
+      $('.visbile-table').css('display', '');
+
+      $('.taxopress-tab').css('height', $('.taxopress-tab-content').height());
+    });
+
+    if ($('.taxopress-tab-content').length > 0) {
+      $('.taxopress-tab').css('height', $('.taxopress-tab-content').height());
+    }
 
   
   });

--- a/inc/autolinks-functions.php
+++ b/inc/autolinks-functions.php
@@ -155,7 +155,7 @@ function taxopress_create_default_autolink()
     $default['taxopress_autolink']['embedded']                 = [];
     $default['taxopress_autolink']['html_exclusion']           = [];
     $default['taxopress_autolink']['unattached_terms']         = '0';
-    $default['taxopress_autolink']['ignore_case']              = '0';
+    $default['taxopress_autolink']['ignore_case']              = '1';
     $default['taxopress_autolink']['ignore_attached']          = '0';
     $default['taxopress_autolink']['autolink_dom']             = '0';
     $default['autolink_submit']                                = 'Add Autolinks';
@@ -203,8 +203,8 @@ function taxopress_update_autolink($data = [])
     if (!isset($data['taxopress_autolink']['unattached_terms'])) {
         $data['taxopress_autolink']['unattached_terms'] = 0;
     }
-    if (!isset($data['taxopress_autolink']['ignore_case'])) {
-        $data['taxopress_autolink']['ignore_case'] = 0;
+    if (!isset($data['taxopress_autolink']['ignore_case'])) {//auto set ignore case to true
+        $data['taxopress_autolink']['ignore_case'] = 1;
     }
     if (!isset($data['taxopress_autolink']['ignore_attached'])) {
         $data['taxopress_autolink']['ignore_attached'] = 0;

--- a/inc/autolinks-functions.php
+++ b/inc/autolinks-functions.php
@@ -1,0 +1,370 @@
+<?php
+/**
+ * Fetch our TAXOPRESS Autolinks option.
+ *
+ * @return mixed
+ */
+function taxopress_get_autolink_data()
+{
+    return array_filter((array)apply_filters('taxopress_get_autolink_data', get_option('taxopress_autolinks', []),
+        get_current_blog_id()));
+}
+
+/**
+ * Get the selected autolink from the $_POST global.
+ *
+ * @return bool|string False on no result, sanitized autolink if set.
+ * @internal
+ *
+ */
+function taxopress_get_current_autolink()
+{
+
+    $autolinks = false;
+
+    if (!empty($_GET) && isset($_GET['taxopress_autolinks'])) {
+        $autolinks = sanitize_text_field($_GET['taxopress_autolinks']);
+    } else {
+        $autolinks = taxopress_get_autolink_data();
+        if (!empty($autolinks)) {
+            // Will return the first array key.
+            $autolinks = key($autolinks);
+        }
+    }
+
+    /**
+     * Filters the current autolink to edit.
+     *
+     * @param string $autolinks autolink slug.
+     */
+    return apply_filters('taxopress_current_autolink', $autolinks);
+}
+
+/**
+ * Handle the save and deletion of autolink data.
+ */
+function taxopress_process_autolink()
+{
+
+    if (wp_doing_ajax()) {
+        return;
+    }
+
+    if (!is_admin()) {
+        return;
+    }
+
+    if (empty($_GET)) {
+        return;
+    }
+
+    if (!isset($_GET['page'])) {
+        return;
+    }
+    if ('st_autolinks' !== $_GET['page']) {
+        return;
+    }
+
+    if (isset($_GET['new_autolink'])) {
+        if ((int)$_GET['new_autolink'] === 1) {
+            add_action('admin_notices', "taxopress_autolinks_update_success_admin_notice");
+            add_filter('removable_query_args', 'taxopress_saved_autolink_filter_removable_query_args');
+        }
+    }
+
+    if (isset($_GET['deleted_autolink'])) {
+        if ((int)$_GET['deleted_autolink'] === 1) {
+            add_action('admin_notices', "taxopress_autolinks_delete_success_admin_notice");
+            add_filter('removable_query_args', 'taxopress_deleted_autolink_filter_removable_query_args');
+        }
+    }
+
+
+    if (!empty($_POST) && isset($_POST['autolink_submit'])) {
+        $result = '';
+        if (isset($_POST['autolink_submit'])) {
+            check_admin_referer('taxopress_addedit_autolink_nonce_action',
+                'taxopress_addedit_autolink_nonce_field');
+            $result = taxopress_update_autolink($_POST);
+        }
+
+        if ($result) {
+            wp_safe_redirect(
+                add_query_arg(
+                    [
+                        'page'                => 'st_autolinks',
+                        'add'                 => 'new_item',
+                        'action'              => 'edit',
+                        'taxopress_autolinks' => $result,
+                        'new_autolink'        => 1,
+                    ],
+                    taxopress_admin_url('admin.php')
+                )
+            );
+
+            exit();
+        }
+    } elseif (isset($_REQUEST['action']) && $_REQUEST['action'] === 'taxopress-delete-autolink') {
+        $nonce = esc_attr($_REQUEST['_wpnonce']);
+        if (wp_verify_nonce($nonce, 'autolink-action-request-nonce')) {
+            taxopress_action_delete_autolink($_REQUEST['taxopress_autolinks']);
+        }
+        add_filter('removable_query_args', 'taxopress_delete_autolink_filter_removable_query_args');
+    }
+}
+
+add_action('init', 'taxopress_process_autolink', 8);
+
+
+/**
+ * Create default autolink.
+ */
+function taxopress_create_default_autolink()
+{
+
+    if (wp_doing_ajax()) {
+        return;
+    }
+
+    if (!is_admin()) {
+        return;
+    }
+
+    if ((int)get_option('taxopress_default_autolinks') > 0) {
+        return;
+    }
+
+    if (count(taxopress_get_autolink_data()) > 0) {
+        return;
+    }
+
+    $default                                                   = [];
+    $default['taxopress_autolink']['title']                    = 'Auto link';
+    $default['taxopress_autolink']['taxonomy']                 = 'post_tag';
+    $default['taxopress_autolink']['autolink_case']            = 'none';
+    $default['taxopress_autolink']['autolink_display']         = 'post_content';
+    $default['taxopress_autolink']['autolink_title_attribute'] = __('Posts tagged with %s', 'simpletags');
+    $default['taxopress_autolink']['autolink_usage_min']       = '1';
+    $default['taxopress_autolink']['autolink_usage_max']       = '10';
+    $default['taxopress_autolink']['autolink_same_usage_max']  = '1';
+    $default['taxopress_autolink']['autolink_min_char']        = '';
+    $default['taxopress_autolink']['autolink_max_char']        = '';
+    $default['taxopress_autolink']['autolink_exclude_class']   = '';
+    $default['taxopress_autolink']['hook_priority']            = '12';
+    $default['taxopress_autolink']['embedded']                 = [];
+    $default['taxopress_autolink']['html_exclusion']           = [];
+    $default['taxopress_autolink']['unattached_terms']         = '0';
+    $default['taxopress_autolink']['ignore_case']              = '0';
+    $default['taxopress_autolink']['ignore_attached']          = '0';
+    $default['taxopress_autolink']['autolink_dom']             = '0';
+    $default['autolink_submit']                                = 'Add Autolinks';
+    $default['cpt_tax_status']                                 = 'new';
+    $result                                                    = taxopress_update_autolink($default);
+    update_option('taxopress_default_autolinks', $result);
+}
+
+add_action('init', 'taxopress_create_default_autolink', 8);
+
+
+/**
+ * Add to or update our TAXOPRESS option with new data.
+ *
+ *
+ * @param array $data Array of autolink data to update. Optional.
+ * @return bool|string False on failure, string on success.
+ * @internal
+ *
+ */
+function taxopress_update_autolink($data = [])
+{
+    foreach ($data as $key => $value) {
+
+        if (is_string($value)) {
+            $data[$key] = sanitize_text_field($value);
+        } else {
+            array_map('sanitize_text_field', $data[$key]);
+        }
+    }
+
+    $autolinks = taxopress_get_autolink_data();
+
+    $title                               = $data['taxopress_autolink']['title'];
+    $title                               = str_replace('"', '', htmlspecialchars_decode($title));
+    $title                               = htmlspecialchars($title, ENT_QUOTES);
+    $title                               = trim($title);
+    $data['taxopress_autolink']['title'] = stripslashes_deep($title);
+
+    //update seperate post
+    $data['taxopress_autolink']['embedded']       = isset($data['embedded']) ? $data['embedded'] : [];
+    $data['taxopress_autolink']['html_exclusion'] = isset($data['html_exclusion']) ? $data['html_exclusion'] : [];
+
+    //update our custom checkbox value if not checked
+    if (!isset($data['taxopress_autolink']['unattached_terms'])) {
+        $data['taxopress_autolink']['unattached_terms'] = 0;
+    }
+    if (!isset($data['taxopress_autolink']['ignore_case'])) {
+        $data['taxopress_autolink']['ignore_case'] = 0;
+    }
+    if (!isset($data['taxopress_autolink']['ignore_attached'])) {
+        $data['taxopress_autolink']['ignore_attached'] = 0;
+    }
+    if (!isset($data['taxopress_autolink']['autolink_dom'])) {
+        $data['taxopress_autolink']['autolink_dom'] = 0;
+    }
+
+
+    if (isset($data['edited_autolink'])) {
+        $autolink_id             = $data['edited_autolink'];
+        $autolinks[$autolink_id] = $data['taxopress_autolink'];
+        $success                 = update_option('taxopress_autolinks', $autolinks);
+        //return 'update_success';
+    } else {
+        $autolink_id                      = (int)get_option('taxopress_autolink_ids_increament') + 1;
+        $data['taxopress_autolink']['ID'] = $autolink_id;
+        $autolinks[$autolink_id]          = $data['taxopress_autolink'];
+        $success                          = update_option('taxopress_autolinks', $autolinks);
+        $update_id                        = update_option('taxopress_autolink_ids_increament', $autolink_id);
+        //return 'add_success';
+    }
+
+    return $autolink_id;
+
+}
+
+/**
+ * Successful update callback.
+ */
+function taxopress_autolinks_update_success_admin_notice()
+{
+    echo taxopress_admin_notices_helper(__('Settings updated successfully.', 'simpletags'));
+}
+
+/**
+ * Successful deleted callback.
+ */
+function taxopress_autolinks_delete_success_admin_notice()
+{
+    echo taxopress_admin_notices_helper(__('Autolinks successfully deleted.', 'simpletags'), false);
+}
+
+/**
+ * Filters the list of query arguments which get removed from admin area URLs in WordPress.
+ *
+ * @link https://core.trac.wordpress.org/ticket/23367
+ *
+ * @param string[] $args Array of removable query arguments.
+ * @return string[] Updated array of removable query arguments.
+ */
+function taxopress_saved_autolink_filter_removable_query_args(array $args)
+{
+    return array_merge($args, [
+        'new_autolink',
+    ]);
+}
+
+/**
+ * Filters the list of query arguments which get removed from admin area URLs in WordPress.
+ *
+ * @link https://core.trac.wordpress.org/ticket/23367
+ *
+ * @param string[] $args Array of removable query arguments.
+ * @return string[] Updated array of removable query arguments.
+ */
+function taxopress_deleted_autolink_filter_removable_query_args(array $args)
+{
+    return array_merge($args, [
+        'deleted_autolink',
+    ]);
+}
+
+/**
+ * Filters the list of query arguments which get removed from admin area URLs in WordPress.
+ *
+ * @link https://core.trac.wordpress.org/ticket/23367
+ *
+ * @param string[] $args Array of removable query arguments.
+ * @return string[] Updated array of removable query arguments.
+ */
+function taxopress_delete_autolink_filter_removable_query_args(array $args)
+{
+    return array_merge($args, [
+        'action',
+        'taxopress_autolinks',
+        '_wpnonce',
+    ]);
+}
+
+/**
+ * Delete our custom autolink from the array of autolinks.
+ * @return bool|string False on failure, string on success.
+ */
+function taxopress_action_delete_autolink($autolink_id)
+{
+    $autolinks = taxopress_get_autolink_data();
+
+    if (array_key_exists($autolink_id, $autolinks)) {
+        unset($autolinks[$autolink_id]);
+        $success = update_option('taxopress_autolinks', $autolinks);
+    }
+
+    if (isset($success)) {
+        add_action('admin_notices', "taxopress_taxdeleted_admin_notice");
+        wp_safe_redirect(
+            add_query_arg(
+                [
+                    'page'             => 'st_autolinks',
+                    'deleted_autolink' => 1,
+                ],
+                taxopress_admin_url('admin.php')
+            )
+        );
+        exit();
+    }
+}
+
+/**
+ * Auto add autolink to post content
+ *
+ * @param string $content
+ *
+ * @return string
+ */
+function taxopress_autolinks_the_content($content = '')
+{
+
+    $post_tags = taxopress_get_autolink_data();
+
+    if (count($post_tags) > 0) {
+        foreach ($post_tags as $post_tag) {
+
+            // Get option
+            $embedded = (isset($post_tag['embedded']) && is_array($post_tag['embedded']) && count($post_tag['embedded']) > 0) ? $post_tag['embedded'] : false;
+
+            if (!$embedded) {
+                continue;
+            }
+
+            $marker = false;
+            if (is_feed() && in_array('feed', $embedded)) {
+                $marker = true;
+            } elseif (is_home() && in_array('homeonly', $embedded)) {
+                $marker = true;
+            } elseif (is_feed() && in_array('blogonly', $embedded)) {
+                $marker = true;
+            } elseif (is_singular() && in_array('singleonly', $embedded)) {
+                $marker = true;
+            } elseif (is_singular() && in_array(get_post_type(), $embedded)) {
+                $marker = true;
+            }
+            if (true === $marker) {
+                $autolink_arg = build_query($post_tag);
+                $content      .= SimpleTags_Client_Autolinks::get_autolinks($autolink_arg);
+            }
+        }
+    }
+
+    return $content;
+}
+
+//add_filter('the_content', 'taxopress_autolinks_the_content', 999992);
+?>

--- a/inc/autolinks-functions.php
+++ b/inc/autolinks-functions.php
@@ -145,6 +145,7 @@ function taxopress_create_default_autolink()
     $default['taxopress_autolink']['autolink_display']         = 'post_content';
     $default['taxopress_autolink']['autolink_title_attribute'] = __('Posts tagged with %s', 'simpletags');
     $default['taxopress_autolink']['autolink_usage_min']       = '1';
+    $default['taxopress_autolink']['auto_link_exclude']        = '';
     $default['taxopress_autolink']['autolink_usage_max']       = '10';
     $default['taxopress_autolink']['autolink_same_usage_max']  = '1';
     $default['taxopress_autolink']['autolink_min_char']        = '';
@@ -321,50 +322,4 @@ function taxopress_action_delete_autolink($autolink_id)
         exit();
     }
 }
-
-/**
- * Auto add autolink to post content
- *
- * @param string $content
- *
- * @return string
- */
-function taxopress_autolinks_the_content($content = '')
-{
-
-    $post_tags = taxopress_get_autolink_data();
-
-    if (count($post_tags) > 0) {
-        foreach ($post_tags as $post_tag) {
-
-            // Get option
-            $embedded = (isset($post_tag['embedded']) && is_array($post_tag['embedded']) && count($post_tag['embedded']) > 0) ? $post_tag['embedded'] : false;
-
-            if (!$embedded) {
-                continue;
-            }
-
-            $marker = false;
-            if (is_feed() && in_array('feed', $embedded)) {
-                $marker = true;
-            } elseif (is_home() && in_array('homeonly', $embedded)) {
-                $marker = true;
-            } elseif (is_feed() && in_array('blogonly', $embedded)) {
-                $marker = true;
-            } elseif (is_singular() && in_array('singleonly', $embedded)) {
-                $marker = true;
-            } elseif (is_singular() && in_array(get_post_type(), $embedded)) {
-                $marker = true;
-            }
-            if (true === $marker) {
-                $autolink_arg = build_query($post_tag);
-                $content      .= SimpleTags_Client_Autolinks::get_autolinks($autolink_arg);
-            }
-        }
-    }
-
-    return $content;
-}
-
-//add_filter('the_content', 'taxopress_autolinks_the_content', 999992);
 ?>

--- a/inc/autolinks-table.php
+++ b/inc/autolinks-table.php
@@ -1,0 +1,394 @@
+<?php
+if (!class_exists('WP_List_Table')) {
+    require_once(ABSPATH . 'wp-admin/includes/class-wp-list-table.php');
+}
+
+class Autolinks_List extends WP_List_Table
+{
+
+    /** Class constructor */
+    public function __construct()
+    {
+
+        parent::__construct([
+            'singular' => __('Autolink', 'simpletags'), //singular name of the listed records
+            'plural'   => __('Autolinks', 'simpletags'), //plural name of the listed records
+            'ajax'     => false //does this table support ajax?
+        ]);
+
+    }
+
+    /**
+     * Retrieve st_autolinks data from the database
+     *
+     * @param int $per_page
+     * @param int $page_number
+     *
+     * @return mixed
+     */
+    public static function get_st_autolinks()
+    {
+        return taxopress_get_autolink_data();
+    }
+
+    /**
+     * Returns the count of records in the database.
+     *
+     * @return null|string
+     */
+    public static function record_count()
+    {
+        return count(taxopress_get_autolink_data());
+    }
+
+    /**
+     * Show single row item
+     *
+     * @param array $item
+     */
+    public function single_row($item)
+    {
+        $class = ['st-autolink-tr'];
+        $id    = 'st-autolink-' . md5($item['ID']);
+        echo sprintf('<tr id="%s" class="%s">', $id, implode(' ', $class));
+        $this->single_row_columns($item);
+        echo '</tr>';
+    }
+
+    /**
+     *  Associative array of columns
+     *
+     * @return array
+     */
+    function get_columns()
+    {
+        $columns = [
+            'title'     => __('Title', 'simpletags'),
+            'taxonomy'  => __('Taxonomy', 'simpletags'),
+            'embedded'  => __('Autolink Post type', 'simpletags'),
+            'autolink_display'  => __('Autolink', 'simpletags')
+        ];
+
+        return $columns;
+    }
+
+    /**
+     * Render a column when no column specific method exist.
+     *
+     * @param array $item
+     * @param string $column_name
+     *
+     * @return mixed
+     */
+    public function column_default($item, $column_name)
+    {
+        return !empty($item[$column_name]) ? $item[$column_name] : '&mdash;';
+    }
+
+    /** Text displayed when no stterm data is available */
+    public function no_items()
+    {
+        _e('No item avaliable.', 'simpletags');
+    }
+
+    /**
+     * Displays the search box.
+     *
+     * @param string $text The 'submit' button label.
+     * @param string $input_id ID attribute value for the search input field.
+     *
+     *
+     */
+    public function search_box($text, $input_id)
+    {
+        if (empty($_REQUEST['s']) && !$this->has_items()) {
+            return;
+        }
+
+        $input_id = $input_id . '-search-input';
+
+        if (!empty($_REQUEST['orderby'])) {
+            echo '<input type="hidden" name="orderby" value="' . esc_attr($_REQUEST['orderby']) . '" />';
+        }
+        if (!empty($_REQUEST['order'])) {
+            echo '<input type="hidden" name="order" value="' . esc_attr($_REQUEST['order']) . '" />';
+        }
+        if (!empty($_REQUEST['page'])) {
+            echo '<input type="hidden" name="page" value="' . esc_attr($_REQUEST['page']) . '" />';
+        }
+        ?>
+        <p class="search-box">
+            <label class="screen-reader-text" for="<?php echo esc_attr($input_id); ?>"><?php echo $text; ?>:</label>
+            <input type="search" id="<?php echo esc_attr($input_id); ?>" name="s"
+                   value="<?php _admin_search_query(); ?>"/>
+            <?php submit_button($text, '', '', false, ['id' => 'search-submit']); ?>
+        </p>
+        <?php
+    }
+
+    /**
+     * Sets up the items (roles) to list.
+     */
+    public function prepare_items()
+    {
+
+        $this->_column_headers = $this->get_column_info();
+
+        /**
+         * First, lets decide how many records per page to show
+         */
+        $per_page = $this->get_items_per_page('st_autolinks_per_page', 20);
+
+        /**
+         * Fetch the data
+         */
+        $data = self::get_st_autolinks();
+
+        /**
+         * Handle search
+         */
+        if ((!empty($_REQUEST['s'])) && $search = $_REQUEST['s']) {
+            $data_filtered = [];
+            foreach ($data as $item) {
+                if ($this->str_contains($item['title'], $search, false)) {
+                    $data_filtered[] = $item;
+                }
+            }
+            $data = $data_filtered;
+        }
+
+        /**
+         * This checks for sorting input and sorts the data in our array accordingly.
+         */
+        function usort_reorder($a, $b)
+        {
+            $orderby = (!empty($_REQUEST['orderby'])) ? sanitize_text_field($_REQUEST['orderby']) : 'ID'; //If no sort, default to role
+            $order   = (!empty($_REQUEST['order'])) ? sanitize_text_field($_REQUEST['order']) : 'desc'; //If no order, default to asc
+            $result  = strnatcasecmp($a[$orderby],
+                $b[$orderby]); //Determine sort order, case insensitive, natural order
+
+            return ($order === 'asc') ? $result : -$result; //Send final sort direction to usort
+        }
+
+        usort($data, 'usort_reorder');
+
+        /**
+         * Pagination.
+         */
+        $current_page = $this->get_pagenum();
+        $total_items  = count($data);
+
+
+        /**
+         * The WP_List_Table class does not handle pagination for us, so we need
+         * to ensure that the data is trimmed to only the current page. We can use
+         * array_slice() to
+         */
+        $data = array_slice($data, (($current_page - 1) * $per_page), $per_page);
+
+        /**
+         * Now we can add the data to the items property, where it can be used by the rest of the class.
+         */
+        $this->items = $data;
+
+        /**
+         * We also have to register our pagination options & calculations.
+         */
+        $this->set_pagination_args([
+            'total_items' => $total_items,                      //calculate the total number of items
+            'per_page'    => $per_page,                         //determine how many items to show on a page
+            'total_pages' => ceil($total_items / $per_page)   //calculate the total number of pages
+        ]);
+    }
+
+    /**
+     * Determine if a given string contains a given substring.
+     *
+     * @param string $haystack
+     * @param string|array $needles
+     * @param bool $sensitive Use case sensitive search
+     *
+     * @return bool
+     */
+    public function str_contains($haystack, $needles, $sensitive = true)
+    {
+        foreach ((array)$needles as $needle) {
+            $function = $sensitive ? 'mb_strpos' : 'mb_stripos';
+            if ($needle !== '' && $function($haystack, $needle) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Columns to make sortable.
+     *
+     * @return array
+     */
+    protected function get_sortable_columns()
+    {
+        $sortable_columns = [
+            'title'    => ['title', true],
+            'taxonomy' => ['taxonomy', true],
+        ];
+
+        return $sortable_columns;
+    }
+
+    /**
+     * Generates and display row actions links for the list table.
+     *
+     * @param object $item The item being acted upon.
+     * @param string $column_name Current column name.
+     * @param string $primary Primary column name.
+     *
+     * @return string The row actions HTML, or an empty string if the current column is the primary column.
+     */
+    protected function handle_row_actions($item, $column_name, $primary)
+    {
+        //Build row actions
+        $actions = [
+            'edit'   => sprintf(
+                '<a href="%s">%s</a>',
+                add_query_arg(
+                    [
+                        'page'                   => 'st_autolinks',
+                        'add'                    => 'new_item',
+                        'action'                 => 'edit',
+                        'taxopress_autolinks' => $item['ID'],
+                    ],
+                    admin_url('admin.php')
+                ),
+                __('Edit', 'simpletags')
+            ),
+            'delete' => sprintf(
+                '<a href="%s" class="delete-autolink">%s</a>',
+                add_query_arg([
+                    'page'                   => 'st_autolinks',
+                    'action'                 => 'taxopress-delete-autolink',
+                    'taxopress_autolinks' => esc_attr($item['ID']),
+                    '_wpnonce'               => wp_create_nonce('autolink-action-request-nonce')
+                ],
+                    admin_url('admin.php')),
+                __('Delete', 'simpletags')
+            ),
+        ];
+
+        return $column_name === $primary ? $this->row_actions($actions, false) : '';
+    }
+
+    /**
+     * Method for title column
+     *
+     * @param array $item
+     *
+     * @return string
+     */
+    protected function column_title($item)
+    {
+        $title = sprintf(
+            '<a href="%1$s"><strong><span class="row-title">%2$s</span></strong></a>',
+            add_query_arg(
+                [
+                    'page'                   => 'st_autolinks',
+                    'add'                    => 'new_item',
+                    'action'                 => 'edit',
+                    'taxopress_autolinks' => $item['ID'],
+                ],
+                admin_url('admin.php')
+            ),
+            esc_html($item['title'])
+        );
+
+        return $title;
+    }
+
+    /**
+     * Method for taxonomy column
+     *
+     * @param array $item
+     *
+     * @return string
+     */
+    protected function column_taxonomy($item)
+    {
+        $taxonomy = get_taxonomy($item['taxonomy']);
+
+        return $taxonomy->labels->name;
+    }
+
+    /**
+     * The action column
+     *
+     * @param $item
+     *
+     * @return string
+     */
+    protected function column_embedded($item)
+    {
+        $embedded = (isset($item['embedded']) && is_array($item['embedded']) && count($item['embedded']) > 0) ? $item['embedded'] : false;
+        if ($embedded) {
+            $args = apply_filters('taxopress_attach_post_types_to_taxonomy', ['public' => true]);
+            if (!is_array($args)) {
+                $args = ['public' => true];
+            }
+            $output     = 'objects'; // Or objects.
+            $post_types = apply_filters('taxopress_get_post_types_for_taxonomies', get_post_types($args, $output),
+                $args, $output);
+
+            $result_array     = [];
+            $embedded_options = [
+                'homeonly'   => esc_attr__('Homepage', 'simpletags'),
+                'blogonly'   => esc_attr__('Blog display', 'simpletags'),
+                'singleonly' => esc_attr__('Single post display', 'simpletags'),
+                'feed'       => esc_attr__('RSS feed', 'simpletags'),
+            ];
+            foreach ($post_types as $post_type) {
+                $embedded_options[$post_type->name] = $post_type->label;
+            }
+            foreach ($embedded as $location) {
+                $result_array[] = isset($embedded_options[$location]) ? $embedded_options[$location] : '';
+            }
+            $result = join(', ', $result_array);
+        } else {
+            $result = esc_attr__('None', 'simpletags');
+        }
+
+        return $result;
+    }
+
+    /**
+     * The action column
+     *
+     * @param $item
+     *
+     * @return string
+     */
+    protected function column_autolink_display($item)
+    {
+            $autolink_display_options = [
+                'post_content'   => esc_attr__('Post Content', 'simpletags'),
+                'post_title'   => esc_attr__('Post Title', 'simpletags'),
+                'posts' => esc_attr__('Post Content and Title', 'simpletags'),
+            ];
+
+        return $autolink_display_options[$item['autolink_display']];
+    }
+
+    /**
+     * The action column
+     *
+     * @param $item
+     *
+     * @return string
+     */
+    protected function column_shortcode($item)
+    {
+
+        return '<input type="text" value=\'[taxopress_autolinks id="' . $item['ID'] . '"]\' />';
+    }
+
+
+}

--- a/inc/autolinks.php
+++ b/inc/autolinks.php
@@ -371,6 +371,10 @@ class SimpleTags_Autolink
                                                                 'default' => 'true'
                                                             ],
                                                             [
+                                                                'attr' => 'termcase',
+                                                                'text' => esc_attr__('Term case', 'simpletags')
+                                                            ],
+                                                            [
                                                                 'attr' => 'uppercase',
                                                                 'text' => esc_attr__('Uppercase', 'simpletags')
                                                             ],
@@ -708,32 +712,6 @@ class SimpleTags_Autolink
                                                             ],
                                                         ],
                                                     ];
-                                                    $selected           = (isset($current) && isset($current['ignore_case'])) ? taxopress_disp_boolean($current['ignore_case']) : '';
-                                                    $select['selected'] = !empty($selected) ? $current['ignore_case'] : '';
-                                                    echo $ui->get_select_checkbox_input([
-                                                        'namearray'  => 'taxopress_autolink',
-                                                        'name'       => 'ignore_case',
-                                                        'labeltext'  => esc_html__('Ignore case for auto link ?',
-                                                            'simpletags'),
-                                                        'aftertext'  => __('Example: If you ignore case, auto link feature will replace the word "wordpress" by the tag link "WordPress".',
-                                                            'simpletags'),
-                                                        'selections' => $select,
-                                                    ]);
-
-
-                                                    $select             = [
-                                                        'options' => [
-                                                            [
-                                                                'attr'    => '0',
-                                                                'text'    => esc_attr__('False', 'simpletags'),
-                                                                'default' => 'true',
-                                                            ],
-                                                            [
-                                                                'attr' => '1',
-                                                                'text' => esc_attr__('True', 'simpletags'),
-                                                            ],
-                                                        ],
-                                                    ];
                                                     $selected           = (isset($current) && isset($current['ignore_attached'])) ? taxopress_disp_boolean($current['ignore_attached']) : '';
                                                     $select['selected'] = !empty($selected) ? $current['ignore_attached'] : '';
                                                     echo $ui->get_select_checkbox_input([
@@ -741,7 +719,7 @@ class SimpleTags_Autolink
                                                         'name'       => 'ignore_attached',
                                                         'labeltext'  => esc_html__('Ignore attached term autolink',
                                                             'simpletags'),
-                                                        'aftertext'  => __('Don\'t add autolink if the term is already applied to the article.',
+                                                        'aftertext'  => __('Don\'t add autolink if the term is already assigned to the article.',
                                                             'simpletags'),
                                                         'selections' => $select,
                                                     ]);

--- a/inc/autolinks.php
+++ b/inc/autolinks.php
@@ -549,7 +549,7 @@ class SimpleTags_Autolink
                                                         'namearray' => 'taxopress_autolink',
                                                         'name'      => 'autolink_min_char',
                                                         'textvalue' => isset($current['autolink_min_char']) ? esc_attr($current['autolink_min_char']) : '',
-                                                        'labeltext' => esc_html__('Minumum character length for an autolink',
+                                                        'labeltext' => esc_html__('Minimum character length for an autolink',
                                                             'simpletags'),
                                                         'helptext'  => __('For example, \'4\' would only link tags that are of 4 characters or more in length',
                                                             'simpletags'),
@@ -579,6 +579,18 @@ class SimpleTags_Autolink
                                                 <table class="form-table taxopress-table autolink_exceptions"
                                                        style="display:none;">
                                                     <?php
+
+
+                                                    echo $ui->get_text_input([
+                                                        'namearray' => 'taxopress_autolink',
+                                                        'name'      => 'auto_link_exclude',
+                                                        'textvalue' => isset($current['auto_link_exclude']) ? esc_attr($current['auto_link_exclude']) : '',
+                                                        'labeltext' => esc_html__('Exclude some terms from tag link.',
+                                                            'simpletags'),
+                                                        'helptext'  => esc_html__('Example: If you enter the term "Paris", "City", the auto link tags feature will never replace these terms',
+                                                            'simpletags'),
+                                                        'required'  => false,
+                                                    ]);
 
 
                                                     echo $ui->get_text_input([

--- a/inc/autolinks.php
+++ b/inc/autolinks.php
@@ -1,0 +1,856 @@
+<?php
+
+class SimpleTags_Autolink
+{
+
+    const MENU_SLUG = 'st_options';
+
+    // class instance
+    static $instance;
+
+    // WP_List_Table object
+    public $terms_table;
+
+    /**
+     * Constructor
+     *
+     * @return void
+     * @author Olatechpro
+     */
+    public function __construct()
+    {
+
+        add_filter('set-screen-option', [__CLASS__, 'set_screen'], 10, 3);
+        // Admin menu
+        add_action('admin_menu', [$this, 'admin_menu']);
+
+        // Javascript
+        add_action('admin_enqueue_scripts', [__CLASS__, 'admin_enqueue_scripts'], 11);
+
+    }
+
+    /**
+     * Init somes JS and CSS need for this feature
+     *
+     * @return void
+     * @author Olatechpro
+     */
+    public static function admin_enqueue_scripts()
+    {
+
+        // add JS for manage click tags
+        if (isset($_GET['page']) && $_GET['page'] == 'st_autolinks') {
+            wp_enqueue_style('st-taxonomies-css');
+        }
+    }
+
+    public static function set_screen($status, $option, $value)
+    {
+        return $value;
+    }
+
+    /** Singleton instance */
+    public static function get_instance()
+    {
+        if (!isset(self::$instance)) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Add WP admin menu for Tags
+     *
+     * @return void
+     * @author Olatechpro
+     */
+    public function admin_menu()
+    {
+        $hook = add_submenu_page(
+            self::MENU_SLUG,
+            __('Autolinks', 'simpletags'),
+            __('Autolinks', 'simpletags'),
+            'simple_tags',
+            'st_autolinks',
+            [
+                $this,
+                'page_manage_autolinks',
+            ]
+        );
+
+        add_action("load-$hook", [$this, 'screen_option']);
+    }
+
+    /**
+     * Screen options
+     */
+    public function screen_option()
+    {
+
+        $option = 'per_page';
+        $args   = [
+            'label'   => __('Number of items per page', 'simpletags'),
+            'default' => 20,
+            'option'  => 'st_autolinks_per_page'
+        ];
+
+        add_screen_option($option, $args);
+
+        $this->terms_table = new Autolinks_List();
+    }
+
+    /**
+     * Method for build the page HTML manage tags
+     *
+     * @return void
+     * @author Olatechpro
+     */
+    public function page_manage_autolinks()
+    {
+        // Default order
+        if (!isset($_GET['order'])) {
+            $_GET['order'] = 'name-asc';
+        }
+
+        settings_errors(__CLASS__);
+
+        if (!isset($_GET['add'])) {
+            //all tax
+            ?>
+            <div class="wrap st_wrap st-manage-taxonomies-page">
+
+            <div id="">
+                <h1 class="wp-heading-inline"><?php _e('Autolinks', 'simpletags'); ?></h1>
+                <a href="<?php echo esc_url(admin_url('admin.php?page=st_autolinks&add=new_item')); ?>"
+                   class="page-title-action"><?php esc_html_e('Add New', 'simpletags'); ?></a>
+
+                <div class="taxopress-description">This feature allows you set up different taxonomy autolink
+                    instances.
+                </div>
+
+
+                <?php
+                if (isset($_REQUEST['s']) && $search = esc_attr(wp_unslash($_REQUEST['s']))) {
+                    /* translators: %s: search keywords */
+                    printf(' <span class="subtitle">' . __('Search results for &#8220;%s&#8221;',
+                            'simpletags') . '</span>', $search);
+                }
+                ?>
+                <?php
+
+                //the terms table instance
+                $this->terms_table->prepare_items();
+                ?>
+
+
+                <hr class="wp-header-end">
+                <div id="ajax-response"></div>
+                <form class="search-form wp-clearfix st-taxonomies-search-form" method="get">
+                    <?php $this->terms_table->search_box(__('Search Autolinks', 'simpletags'), 'term'); ?>
+                </form>
+                <div class="clear"></div>
+
+                <div id="col-container" class="wp-clearfix">
+
+                    <div class="col-wrap">
+                        <form action="<?php echo add_query_arg('', '') ?>" method="post">
+                            <?php $this->terms_table->display(); //Display the table ?>
+                        </form>
+                        <div class="form-wrap edit-term-notes">
+                            <p><?php __('Description here.', 'simpletags') ?></p>
+                        </div>
+                    </div>
+
+
+                </div>
+
+
+            </div>
+        <?php } else {
+            if ($_GET['add'] == 'new_item') {
+                //add/edit taxonomy
+                $this->taxopress_manage_autolinks();
+                echo '<div>';
+            }
+        } ?>
+
+
+        <?php SimpleTags_Admin::printAdminFooter(); ?>
+        </div>
+        <?php
+    }
+
+
+    /**
+     * Create our settings page output.
+     *
+     * @internal
+     */
+    public function taxopress_manage_autolinks()
+    {
+
+        $tab       = (!empty($_GET) && !empty($_GET['action']) && 'edit' == $_GET['action']) ? 'edit' : 'new';
+        $tab_class = 'taxopress-' . $tab;
+        $current   = null;
+
+        ?>
+
+    <div class="wrap <?php echo esc_attr($tab_class); ?>">
+
+        <?php
+
+        $autolinks      = taxopress_get_autolink_data();
+        $autolink_edit  = false;
+        $autolink_limit = false;
+
+        if ('edit' === $tab) {
+
+
+            $selected_autolink = taxopress_get_current_autolink();
+
+            if ($selected_autolink && array_key_exists($selected_autolink, $autolinks)) {
+                $current       = $autolinks[$selected_autolink];
+                $autolink_edit = true;
+            }
+
+        }
+
+
+        if (!isset($current['title']) && count($autolinks) > 0 && apply_filters('taxopress_autolinks_create_limit',
+                true)) {
+            $autolink_limit = true;
+        }
+
+
+        $ui = new taxopress_admin_ui();
+        ?>
+
+
+        <div class="wrap <?php echo esc_attr($tab_class); ?>">
+            <h1><?php echo __('Manage Autolinks', 'simpletags'); ?></h1>
+            <div class="wp-clearfix"></div>
+
+            <form method="post" action="">
+
+
+                <div class="tagcloudui st-tabbed">
+
+
+                    <div class="autolinks-postbox-container">
+                        <div id="poststuff">
+                            <div class="taxopress-section postbox">
+                                <div class="postbox-header">
+                                    <h2 class="hndle ui-sortable-handle">
+                                        <?php
+                                        if ($autolink_edit) {
+                                            echo esc_html__('Edit Autolinks', 'simpletags');
+                                            echo '<input type="hidden" name="edited_autolink" value="' . $current['ID'] . '" />';
+                                            echo '<input type="hidden" name="taxopress_autolink[ID]" value="' . $current['ID'] . '" />';
+                                        } else {
+                                            echo esc_html__('Add new Autolinks', 'simpletags');
+                                        }
+                                        ?>
+                                    </h2>
+                                </div>
+                                <div class="inside">
+                                    <div class="main">
+
+
+                                        <?php if ($autolink_limit) {
+                                            echo '<div class="st-taxonomy-content"><div class="taxopress-warning upgrade-pro">
+                                            <p>
+
+                                            <h2 style="margin-bottom: 5px;">' . __('To create more Autolinks, please upgrade to TaxoPress Pro.',
+                                                    'simpletags') . '</h2>
+                                            ' . __('With TaxoPress Pro, you can create unlimited Autolinks. You can create Autolinks for any taxonomy.',
+                                                    'simpletags') . '
+                                            
+                                            </p>
+                                            </div></div>';
+
+                                        } else {
+                                            ?>
+
+
+                                            <ul class="taxopress-tab">
+                                                <li class="autolink_general_tab active" data-content="autolink_general">
+                                                    <a href="#autolink_general"><span><?php esc_html_e('General',
+                                                                'simpletags'); ?></span></a>
+                                                </li>
+
+                                                <li class="autolink_display_tab" data-content="autolink_display">
+                                                    <a href="#autolink_display"><span><?php esc_html_e('Post Types',
+                                                                'simpletags'); ?></span></a>
+                                                </li>
+
+                                                <li class="autolink_control_tab" data-content="autolink_control">
+                                                    <a href="#autolink_control"><span><?php esc_html_e('Control',
+                                                                'simpletags'); ?></span></a>
+                                                </li>
+
+                                                <li class="autolink_exceptions_tab" data-content="autolink_exceptions">
+                                                    <a href="#autolink_exceptions"><span><?php esc_html_e('Exceptions',
+                                                                'simpletags'); ?></span></a>
+                                                </li>
+
+                                                <li class="autolink_advanced_tab" data-content="autolink_advanced">
+                                                    <a href="#autolink_advanced"><span><?php esc_html_e('Advanced',
+                                                                'simpletags'); ?></span></a>
+                                                </li>
+
+                                            </ul>
+
+                                            <div class="st-taxonomy-content taxopress-tab-content">
+
+
+                                                <table class="form-table taxopress-table autolink_general">
+                                                    <?php
+                                                    echo $ui->get_tr_start();
+
+
+                                                    echo $ui->get_th_start();
+                                                    echo $ui->get_label('name', esc_html__('Title',
+                                                            'simpletags')) . $ui->get_required_span();
+                                                    echo $ui->get_th_end() . $ui->get_td_start();
+
+                                                    echo $ui->get_text_input([
+                                                        'namearray'   => 'taxopress_autolink',
+                                                        'name'        => 'title',
+                                                        'textvalue'   => isset($current['title']) ? esc_attr($current['title']) : '',
+                                                        'maxlength'   => '32',
+                                                        'helptext'    => '',
+                                                        'required'    => true,
+                                                        'placeholder' => false,
+                                                        'wrap'        => false,
+                                                    ]);
+
+
+                                                    $options = [];
+                                                    foreach (get_all_taxopress_taxonomies() as $_taxonomy) {
+                                                        $_taxonomy = $_taxonomy->name;
+                                                        $tax       = get_taxonomy($_taxonomy);
+                                                        if (empty($tax->labels->name)) {
+                                                            continue;
+                                                        }
+                                                        if ($tax->name === 'post_tag') {
+                                                            $options[] = [
+                                                                'attr'    => $tax->name,
+                                                                'text'    => $tax->labels->name,
+                                                                'default' => 'true',
+                                                            ];
+                                                        } else {
+                                                            $options[] = [
+                                                                'attr' => $tax->name,
+                                                                'text' => $tax->labels->name,
+                                                            ];
+                                                        }
+                                                    }
+
+                                                    $select             = [
+                                                        'options' => $options,
+                                                    ];
+                                                    $selected           = isset($current) ? taxopress_disp_boolean($current['taxonomy']) : '';
+                                                    $select['selected'] = !empty($selected) ? $current['taxonomy'] : '';
+                                                    echo $ui->get_select_checkbox_input_main([
+                                                        'namearray'  => 'taxopress_autolink',
+                                                        'name'       => 'taxonomy',
+                                                        'class'      => 'st-post-taxonomy-select',
+                                                        'labeltext'  => esc_html__('Taxonomy', 'simpletags'),
+                                                        'required'   => true,
+                                                        'selections' => $select,
+                                                    ]);
+
+
+                                                    $select             = [
+                                                        'options' => [
+                                                            [
+                                                                'attr'    => 'none',
+                                                                'text'    => esc_attr__('Retain content case',
+                                                                    'simpletags'),
+                                                                'default' => 'true'
+                                                            ],
+                                                            [
+                                                                'attr' => 'uppercase',
+                                                                'text' => esc_attr__('Uppercase', 'simpletags')
+                                                            ],
+                                                            [
+                                                                'attr' => 'lowercase',
+                                                                'text' => esc_attr__('Lowercase', 'simpletags')
+                                                            ],
+                                                        ],
+                                                    ];
+                                                    $selected           = isset($current) ? taxopress_disp_boolean($current['autolink_case']) : '';
+                                                    $select['selected'] = !empty($selected) ? $current['autolink_case'] : '';
+                                                    echo $ui->get_select_number_select([
+                                                        'namearray'  => 'taxopress_autolink',
+                                                        'name'       => 'autolink_case',
+                                                        'labeltext'  => esc_html__('Autolink case',
+                                                            'simpletags'),
+                                                        'selections' => $select,
+                                                    ]);
+
+                                                    $select             = [
+                                                        'options' => [
+                                                            [
+                                                                'attr'    => 'post_content',
+                                                                'text'    => esc_attr__('Post Content', 'simpletags'),
+                                                                'default' => 'true'
+                                                            ],
+                                                            [
+                                                                'attr' => 'post_title',
+                                                                'text' => esc_attr__('Post Title', 'simpletags')
+                                                            ],
+                                                            [
+                                                                'attr' => 'posts',
+                                                                'text' => esc_attr__('Post Content and Title',
+                                                                    'simpletags')
+                                                            ],
+                                                        ],
+                                                    ];
+                                                    $selected           = isset($current) ? taxopress_disp_boolean($current['autolink_display']) : '';
+                                                    $select['selected'] = !empty($selected) ? $current['autolink_display'] : '';
+                                                    echo $ui->get_select_number_select([
+                                                        'namearray'  => 'taxopress_autolink',
+                                                        'name'       => 'autolink_display',
+                                                        'labeltext'  => esc_html__('Autolink in:',
+                                                            'simpletags'),
+                                                        'selections' => $select,
+                                                    ]);
+
+
+                                                    echo $ui->get_text_input([
+                                                        'namearray' => 'taxopress_autolink',
+                                                        'name'      => 'autolink_title_attribute',
+                                                        'textvalue' => isset($current['autolink_title_attribute']) ? esc_attr($current['autolink_title_attribute']) : 'Posts tagged with %s',
+                                                        'labeltext' => esc_html__('Auto link title attribute:',
+                                                            'simpletags'),
+                                                        'helptext'  => '',
+                                                        'required'  => false,
+                                                    ]);
+
+                                                    echo $ui->get_td_end() . $ui->get_tr_end();
+                                                    ?>
+                                                </table>
+
+
+                                                <table class="form-table taxopress-table autolink_display"
+                                                       style="display:none;">
+                                                    <?php
+
+
+                                                    /**
+                                                     * Filters the arguments for post types to list for taxonomy association.
+                                                     *
+                                                     *
+                                                     * @param array $value Array of default arguments.
+                                                     */
+                                                    $args = apply_filters('taxopress_attach_post_types_to_taxonomy',
+                                                        ['public' => true]);
+
+                                                    // If they don't return an array, fall back to the original default. Don't need to check for empty, because empty array is default for $args param in get_post_types anyway.
+                                                    if (!is_array($args)) {
+                                                        $args = ['public' => true];
+                                                    }
+                                                    $output = 'objects'; // Or objects.
+
+                                                    /**
+                                                     * Filters the results returned to display for available post types for taxonomy.
+                                                     *
+                                                     * @param array $value Array of post type objects.
+                                                     * @param array $args Array of arguments for the post type query.
+                                                     * @param string $output The output type we want for the results.
+                                                     */
+                                                    $post_types = apply_filters('taxopress_get_post_types_for_taxonomies',
+                                                        get_post_types($args, $output), $args, $output);
+
+                                                    $term_auto_locations = [];
+                                                    foreach ($post_types as $post_type) {
+                                                        $term_auto_locations[$post_type->name] = $post_type->label;
+                                                    }
+
+                                                    echo '<tr valign="top"><th scope="row"><label>' . esc_html__('Enable this autolinks instance for:',
+                                                            'simpletags') . '</label><br /><small style=" color: #646970;">' . esc_html__('TaxoPress will attempt to automatically autolinks in this content. It may not be successful for all post types and layouts.',
+                                                            'simpletags') . '</small></th><td>
+                                                    <table class="visbile-table">';
+                                                    foreach ($term_auto_locations as $key => $value) {
+
+
+                                                        echo '<tr valign="top"><th scope="row"><label for="' . $key . '">' . $value . '</label></th><td>';
+
+                                                        echo $ui->get_check_input([
+                                                            'checkvalue' => $key,
+                                                            'checked'    => (!empty($current['embedded']) && is_array($current['embedded']) && in_array($key,
+                                                                    $current['embedded'], true)) ? 'true' : 'false',
+                                                            'name'       => $key,
+                                                            'namearray'  => 'embedded',
+                                                            'textvalue'  => $key,
+                                                            'labeltext'  => "",
+                                                            'wrap'       => false,
+                                                        ]);
+
+                                                        echo '</td></tr>';
+
+
+                                                    }
+                                                    echo '</table></td></tr>';
+
+
+                                                    ?>
+
+                                                </table>
+
+
+                                                <table class="form-table taxopress-table autolink_control"
+                                                       style="display:none;">
+                                                    <?php
+
+
+                                                    echo $ui->get_number_input([
+                                                        'namearray' => 'taxopress_autolink',
+                                                        'name'      => 'autolink_usage_min',
+                                                        'textvalue' => isset($current['autolink_usage_min']) ? esc_attr($current['autolink_usage_min']) : '1',
+                                                        'labeltext' => esc_html__('Minimum usage for auto link tags',
+                                                            'simpletags'),
+                                                        'helptext'  => __('This parameter allows to fix a minimal count value a term must have to be auto link.',
+                                                            'simpletags'),
+                                                        'min'       => '1',
+                                                        'required'  => true,
+                                                    ]);
+
+
+                                                    echo $ui->get_number_input([
+                                                        'namearray' => 'taxopress_autolink',
+                                                        'name'      => 'autolink_usage_max',
+                                                        'textvalue' => isset($current['autolink_usage_max']) ? esc_attr($current['autolink_usage_max']) : '10',
+                                                        'labeltext' => esc_html__('Maximum number of links per article',
+                                                            'simpletags'),
+                                                        'helptext'  => __('This setting determines the maximum number of autolinks for article.',
+                                                            'simpletags'),
+                                                        'min'       => '1',
+                                                        'required'  => true,
+                                                    ]);
+
+
+                                                    echo $ui->get_number_input([
+                                                        'namearray' => 'taxopress_autolink',
+                                                        'name'      => 'autolink_same_usage_max',
+                                                        'textvalue' => isset($current['autolink_same_usage_max']) ? esc_attr($current['autolink_same_usage_max']) : '1',
+                                                        'labeltext' => esc_html__('Maximum number of links for the same tag',
+                                                            'simpletags'),
+                                                        'helptext'  => __('This setting determines the maximum number of autolink of same terms.',
+                                                            'simpletags'),
+                                                        'min'       => '1',
+                                                        'required'  => true,
+                                                    ]);
+
+
+                                                    echo $ui->get_number_input([
+                                                        'namearray' => 'taxopress_autolink',
+                                                        'name'      => 'autolink_min_char',
+                                                        'textvalue' => isset($current['autolink_min_char']) ? esc_attr($current['autolink_min_char']) : '',
+                                                        'labeltext' => esc_html__('Minumum character length for an autolink',
+                                                            'simpletags'),
+                                                        'helptext'  => __('For example, \'4\' would only link tags that are of 4 characters or more in length',
+                                                            'simpletags'),
+                                                        'min'       => '0',
+                                                        'required'  => false,
+                                                    ]);
+
+
+                                                    echo $ui->get_number_input([
+                                                        'namearray' => 'taxopress_autolink',
+                                                        'name'      => 'autolink_max_char',
+                                                        'textvalue' => isset($current['autolink_max_char']) ? esc_attr($current['autolink_max_char']) : '',
+                                                        'labeltext' => esc_html__('Maximum character length for an autolink',
+                                                            'simpletags'),
+                                                        'helptext'  => __('For example, \'4\' would only link tags that are of 4 characters or less in length',
+                                                            'simpletags'),
+                                                        'min'       => '0',
+                                                        'required'  => false,
+                                                    ]);
+
+
+                                                    ?>
+
+                                                </table>
+
+
+                                                <table class="form-table taxopress-table autolink_exceptions"
+                                                       style="display:none;">
+                                                    <?php
+
+
+                                                    echo $ui->get_text_input([
+                                                        'namearray' => 'taxopress_autolink',
+                                                        'name'      => 'autolink_exclude_class',
+                                                        'textvalue' => isset($current['autolink_exclude_class']) ? esc_attr($current['autolink_exclude_class']) : '',
+                                                        'labeltext' => esc_html__('Exclude tags wrapped in div class/id',
+                                                            'simpletags'),
+                                                        'helptext'  => esc_html__('Seperate multiple entry by comma. E.g, .notag, #main-header etc',
+                                                            'simpletags'),
+                                                        'required'  => false,
+                                                    ]);
+
+                                                    $html_exclusions = [
+                                                        //tags
+                                                        'script' => esc_attr__('script', 'simpletags'),
+                                                        //headers
+                                                        'h1'     => esc_attr__('H1', 'simpletags'),
+                                                        'h2'     => esc_attr__('H2', 'simpletags'),
+                                                        'h3'     => esc_attr__('H3', 'simpletags'),
+                                                        'h4'     => esc_attr__('H4', 'simpletags'),
+                                                        'h5'     => esc_attr__('H5', 'simpletags'),
+                                                        'h6'     => esc_attr__('H6', 'simpletags'),
+                                                    ];
+
+                                                    echo '<tr valign="top"><th scope="row"><label>' . esc_html__('Exclude autolinks inside these elements:',
+                                                            'simpletags') . '</label><br /><small style=" color: #646970;">' . esc_html__('Selecting any of these option will exlude autolink of terms found in-between the element tags',
+                                                            'simpletags') . '</small></th><td>
+                                                    <table class="visbile-table">';
+                                                    foreach ($html_exclusions as $key => $value) {
+
+                                                        echo '<tr valign="top"><th scope="row"><label for="' . $key . '">' . $value . '</label></th><td>';
+
+                                                        echo $ui->get_check_input([
+                                                            'checkvalue' => $key,
+                                                            'checked'    => (!empty($current['html_exclusion']) && is_array($current['html_exclusion']) && in_array($key,
+                                                                    $current['html_exclusion'],
+                                                                    true)) ? 'true' : 'false',
+                                                            'name'       => $key,
+                                                            'namearray'  => 'html_exclusion',
+                                                            'textvalue'  => $key,
+                                                            'labeltext'  => "",
+                                                            'wrap'       => false,
+                                                        ]);
+
+                                                        echo '</td></tr>';
+
+                                                        if ($key === 'script') {
+                                                            echo '<tr valign="top"><th style="padding: 0;" scope="row"><hr /></th><td style="padding: 0;"><hr /></td></tr>';
+                                                        }
+
+
+                                                    }
+                                                    echo '</table></td></tr>';
+
+                                                    ?>
+
+                                                </table>
+
+
+                                                <table class="form-table taxopress-table autolink_advanced"
+                                                       style="display:none;">
+                                                    <?php
+
+
+                                                    echo $ui->get_number_input([
+                                                        'namearray' => 'taxopress_autolink',
+                                                        'name'      => 'hook_priority',
+                                                        'textvalue' => isset($current['hook_priority']) ? esc_attr($current['hook_priority']) : '12',
+                                                        'labeltext' => esc_html__('Priority on the_content and the_title hook',
+                                                            'simpletags'),
+                                                        'helptext'  => __('For expert, possibility to change the priority of autolinks functions on the_content hook. Useful for fix a conflict with an another plugin.',
+                                                            'simpletags'),
+                                                        'min'       => '1',
+                                                        'required'  => false,
+                                                    ]);
+
+
+                                                    $select             = [
+                                                        'options' => [
+                                                            [
+                                                                'attr'    => '0',
+                                                                'text'    => esc_attr__('False', 'simpletags'),
+                                                                'default' => 'true',
+                                                            ],
+                                                            [
+                                                                'attr' => '1',
+                                                                'text' => esc_attr__('True', 'simpletags'),
+                                                            ],
+                                                        ],
+                                                    ];
+                                                    $selected           = (isset($current) && isset($current['unattached_terms'])) ? taxopress_disp_boolean($current['unattached_terms']) : '';
+                                                    $select['selected'] = !empty($selected) ? $current['unattached_terms'] : '';
+                                                    echo $ui->get_select_checkbox_input([
+                                                        'namearray'  => 'taxopress_autolink',
+                                                        'name'       => 'unattached_terms',
+                                                        'labeltext'  => esc_html__('Add links for unattached terms',
+                                                            'simpletags'),
+                                                        'aftertext'  => __('By default, TaxoPress will only add Auto Links for terms that are attached to the post. If this box is checked, TaxoPress will add links for all terms',
+                                                            'simpletags'),
+                                                        'selections' => $select,
+                                                    ]);
+
+
+                                                    $select             = [
+                                                        'options' => [
+                                                            [
+                                                                'attr'    => '0',
+                                                                'text'    => esc_attr__('False', 'simpletags'),
+                                                                'default' => 'true',
+                                                            ],
+                                                            [
+                                                                'attr' => '1',
+                                                                'text' => esc_attr__('True', 'simpletags'),
+                                                            ],
+                                                        ],
+                                                    ];
+                                                    $selected           = (isset($current) && isset($current['ignore_case'])) ? taxopress_disp_boolean($current['ignore_case']) : '';
+                                                    $select['selected'] = !empty($selected) ? $current['ignore_case'] : '';
+                                                    echo $ui->get_select_checkbox_input([
+                                                        'namearray'  => 'taxopress_autolink',
+                                                        'name'       => 'ignore_case',
+                                                        'labeltext'  => esc_html__('Ignore case for auto link ?',
+                                                            'simpletags'),
+                                                        'aftertext'  => __('Example: If you ignore case, auto link feature will replace the word "wordpress" by the tag link "WordPress".',
+                                                            'simpletags'),
+                                                        'selections' => $select,
+                                                    ]);
+
+
+                                                    $select             = [
+                                                        'options' => [
+                                                            [
+                                                                'attr'    => '0',
+                                                                'text'    => esc_attr__('False', 'simpletags'),
+                                                                'default' => 'true',
+                                                            ],
+                                                            [
+                                                                'attr' => '1',
+                                                                'text' => esc_attr__('True', 'simpletags'),
+                                                            ],
+                                                        ],
+                                                    ];
+                                                    $selected           = (isset($current) && isset($current['ignore_attached'])) ? taxopress_disp_boolean($current['ignore_attached']) : '';
+                                                    $select['selected'] = !empty($selected) ? $current['ignore_attached'] : '';
+                                                    echo $ui->get_select_checkbox_input([
+                                                        'namearray'  => 'taxopress_autolink',
+                                                        'name'       => 'ignore_attached',
+                                                        'labeltext'  => esc_html__('Ignore attached term autolink',
+                                                            'simpletags'),
+                                                        'aftertext'  => __('Don\'t add autolink if the term is already applied to the article.',
+                                                            'simpletags'),
+                                                        'selections' => $select,
+                                                    ]);
+
+
+                                                    $select             = [
+                                                        'options' => [
+                                                            [
+                                                                'attr'    => '0',
+                                                                'text'    => esc_attr__('False', 'simpletags'),
+                                                                'default' => 'true',
+                                                            ],
+                                                            [
+                                                                'attr' => '1',
+                                                                'text' => esc_attr__('True', 'simpletags'),
+                                                            ],
+                                                        ],
+                                                    ];
+                                                    $selected           = (isset($current) && isset($current['autolink_dom'])) ? taxopress_disp_boolean($current['autolink_dom']) : '';
+                                                    $select['selected'] = !empty($selected) ? $current['autolink_dom'] : '';
+                                                    echo $ui->get_select_checkbox_input([
+                                                        'namearray'  => 'taxopress_autolink',
+                                                        'name'       => 'autolink_dom',
+                                                        'labeltext'  => esc_html__('Try new engine replacement ?',
+                                                            'simpletags'),
+                                                        'aftertext'  => __('An engine replacement alternative uses DOMDocument PHP class and theoretically offers better performance. If your server does not offer the functionality, the plugin will use the usual engine.',
+                                                            'simpletags'),
+                                                        'selections' => $select,
+                                                    ]);
+
+                                                    ?>
+                                                </table>
+
+
+                                            </div>
+
+
+                                        <?php }//end new fields
+                                        ?>
+
+
+                                        <div class="clear"></div>
+
+
+                                    </div>
+                                </div>
+                            </div>
+
+
+                            <?php if ($autolink_limit) { ?>
+
+                                <div class="pp-version-notice-bold-purple" style="margin-left:0px;">
+                                    <div class="pp-version-notice-bold-purple-message">You're using TaxoPress Free.
+                                        The Pro version has more features and support.
+                                    </div>
+                                    <div class="pp-version-notice-bold-purple-button"><a
+                                            href="https://taxopress.com/pro" target="_blank">Upgrade to Pro</a>
+                                    </div>
+                                </div>
+
+                            <?php } ?>
+                            <?php
+                            /**
+                             * Fires after the default fieldsets on the taxonomy screen.
+                             *
+                             * @param taxopress_admin_ui $ui Admin UI instance.
+                             */
+                            do_action('taxopress_taxonomy_after_fieldsets', $ui);
+                            ?>
+
+                        </div>
+                    </div>
+
+
+                </div>
+
+                <div class="taxopress-right-sidebar">
+                    <div class="taxopress-right-sidebar-wrapper" style="min-height: 205px;">
+
+
+                        <?php
+                        if (!$autolink_limit) { ?>
+                            <p class="submit">
+
+                                <?php
+                                wp_nonce_field('taxopress_addedit_autolink_nonce_action',
+                                    'taxopress_addedit_autolink_nonce_field');
+                                if (!empty($_GET) && !empty($_GET['action']) && 'edit' === $_GET['action']) { ?>
+                                    <input type="submit" class="button-primary taxopress-taxonomy-submit"
+                                           name="autolink_submit"
+                                           value="<?php echo esc_attr(esc_attr__('Save Autolinks',
+                                               'simpletags')); ?>"/>
+                                    <?php
+                                } else { ?>
+                                    <input type="submit" class="button-primary taxopress-taxonomy-submit"
+                                           name="autolink_submit"
+                                           value="<?php echo esc_attr(esc_attr__('Add Autolinks',
+                                               'simpletags')); ?>"/>
+                                <?php } ?>
+
+                                <input type="hidden" name="cpt_tax_status" id="cpt_tax_status"
+                                       value="<?php echo esc_attr($tab); ?>"/>
+                            </p>
+
+                            <?php
+                        }
+                        ?>
+
+                    </div>
+
+                </div>
+
+                <div class="clear"></div>
+
+
+            </form>
+
+        </div><!-- End .wrap -->
+
+        <div class="clear"></div>
+        <?php
+    }
+
+}

--- a/inc/class.admin.php
+++ b/inc/class.admin.php
@@ -26,6 +26,9 @@ class SimpleTags_Admin {
 		// Admin menu
 		add_action( 'admin_menu', array( __CLASS__, 'admin_menu' ) );
 
+        //Admin footer credit
+        add_action( 'in_admin_footer', array( __CLASS__, 'taxopress_admin_footer') );
+
 		// Load JavaScript and CSS
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'admin_enqueue_scripts' ) );
 
@@ -43,6 +46,11 @@ class SimpleTags_Admin {
         require STAGS_DIR . '/inc/related-posts-table.php';
         require STAGS_DIR . '/inc/related-posts.php';
         SimpleTags_Related_Post::get_instance();
+
+        //Auto Links
+        require STAGS_DIR . '/inc/autolinks-table.php';
+        require STAGS_DIR . '/inc/autolinks.php';
+        SimpleTags_Autolink::get_instance();
 
 		// Load custom part of plugin depending option
 		if ( 1 === (int) SimpleTags_Plugin::get_option_value( 'use_suggested_tags' ) ) {
@@ -344,17 +352,7 @@ class SimpleTags_Admin {
 		$wp_post_pages = array( 'post.php', 'post-new.php' );
 		$wp_page_pages = array( 'page.php', 'page-new.php' );
 
-		$taxopress_pages = [
-			'st_mass_terms',
-			'st_auto',
-			'st_options',
-			'st_manage',
-			'st_taxonomies',
-			'st_terms_display',
-			'st_post_tags',
-			'st_related_posts',
-		];
-		$taxopress_pages = apply_filters('taxopress_admin_pages', $taxopress_pages);
+		$taxopress_pages = taxopress_admin_pages();
 
 		// Common Helper for Post, Page and Plugin Page
 		if (
@@ -499,9 +497,26 @@ class SimpleTags_Admin {
 	 * @author WebFactory Ltd
 	 */
 	public static function printAdminFooter() {
+		/* ?>
+		<p class="footer_st"><?php printf( __( 'Thanks for using TaxoPress | <a href="https://taxopress.com/">TaxoPress.com</a> | Version %s', 'simpletags' ), STAGS_VERSION ); ?></p>
+		<?php */
+	}
+
+	/**
+	 * A short public static function for display the same copyright on all taxopress admin pages
+	 *
+	 * @return void
+	 * @author Olatechpro
+	 */
+	public static function taxopress_admin_footer() {
+
+        $taxopress_pages = taxopress_admin_pages();
+
+		if ( isset( $_GET['page'] ) && in_array( $_GET['page'], $taxopress_pages )) {
 		?>
 		<p class="footer_st"><?php printf( __( 'Thanks for using TaxoPress | <a href="https://taxopress.com/">TaxoPress.com</a> | Version %s', 'simpletags' ), STAGS_VERSION ); ?></p>
 		<?php
+        }
 	}
 
 	/**
@@ -523,7 +538,12 @@ class SimpleTags_Admin {
 			$desc_html_tag = 'div';
 
             if($section === 'legacy'){
-                $table_sub_tab = '<div class="st-legacy-subtab"><span class="active" data-content=".legacy-tag-cloud-content">Tag Cloud</span> | <span data-content=".legacy-post-tags-content">Tags for Current Post</span> | <span data-content=".legacy-related-posts-content">Related Posts</span></div>' . PHP_EOL;
+                $table_sub_tab = '<div class="st-legacy-subtab">
+                <span class="active" data-content=".legacy-tag-cloud-content">Tag Cloud</span> | 
+                <span data-content=".legacy-post-tags-content">Tags for Current Post</span> | 
+                <span data-content=".legacy-related-posts-content">Related Posts</span> | 
+                <span data-content=".legacy-auto-link-content">Auto link</span>
+                </div>' . PHP_EOL;
             }else{
                 $table_sub_tab = '';
             }

--- a/inc/class.admin.taxonomies.ui.php
+++ b/inc/class.admin.taxonomies.ui.php
@@ -388,7 +388,7 @@ class taxopress_admin_ui
      */
     public function get_help($help_text = '')
     {
-        return '<a href="#" class="taxopress-help dashicons-before dashicons-editor-help" title="' . esc_attr($help_text) . '"></a>';
+        return '<span class="taxopress-help-tooltip dashicons-before dashicons-editor-help"><span class="tooltip-text">' . esc_html($help_text) . '</span></span>';
     }
 
     /**

--- a/inc/class.client.php
+++ b/inc/class.client.php
@@ -15,11 +15,8 @@ class SimpleTags_Client {
 
         add_action( 'parse_query', array( __CLASS__, 'cpt_taxonomy_parse_query' ) );
 
-		// Call autolinks ?
-		if ( (int) SimpleTags_Plugin::get_option_value( 'auto_link_tags' ) == 1 ) {
-			require( STAGS_DIR . '/inc/class.client.autolinks.php' );
-			new SimpleTags_Client_Autolinks();
-		}
+        require( STAGS_DIR . '/inc/class.client.autolinks.php' );
+        new SimpleTags_Client_Autolinks();
 
 		// Call related posts ?
 		if ( (int) SimpleTags_Plugin::get_option_value( 'active_related_posts' ) == 1 ) {

--- a/inc/functions.inc.php
+++ b/inc/functions.inc.php
@@ -91,3 +91,20 @@ function init_simple_tags()
 
     add_action('widgets_init', 'st_register_widget');
 }
+
+function taxopress_admin_pages(){
+
+    $taxopress_pages = [
+        'st_mass_terms',
+        'st_auto',
+        'st_options',
+        'st_manage',
+        'st_taxonomies',
+        'st_terms_display',
+        'st_post_tags',
+        'st_related_posts',
+        'st_autolinks',
+    ];
+    
+   return apply_filters('taxopress_admin_pages', $taxopress_pages);
+}

--- a/inc/functions.inc.php
+++ b/inc/functions.inc.php
@@ -108,3 +108,14 @@ function taxopress_admin_pages(){
     
    return apply_filters('taxopress_admin_pages', $taxopress_pages);
 }
+
+
+function taxopress_starts_with( $haystack, $needle ) {
+     $length = strlen( $needle );
+     return substr( $haystack, 0, $length ) === $needle;
+}
+
+function taxopress_is_html($string)
+{
+  return preg_match("/<[^<]+>/",$string,$m) != 0;
+}

--- a/inc/helper.options.admin.php
+++ b/inc/helper.options.admin.php
@@ -2,13 +2,6 @@
 return array(
     'features'       => array(
         array(
-            'auto_link_tags',
-            __('Auto links tags', 'simpletags'),
-            'checkbox',
-            '1',
-            __('Example: You have a tag called "WordPress" and your post content contains "wordpress", this feature will replace "wordpress" by a link to "wordpress" tags page. (http://myblog.net/tag/wordpress/)', 'simpletags')
-        ),
-        array(
             'active_mass_edit',
             __('Mass edit terms', 'simpletags'),
             'checkbox',
@@ -86,88 +79,8 @@ return array(
             __('Choose a value between 0 and 1. A high value such as 0.8 will provide a few, accurate suggestions. A low value such as 0.2 will produce more suggestions, but they may be less accurate.', 'simpletags')
         ),
     ),
-    'auto-links'     => array(
-        array(
-            'auto_link_min',
-            __('Min usage for auto link tags:', 'simpletags'),
-            'number',
-            'small-text',
-            __('This parameter allows to fix a minimal value of use of tags. Default: 1.', 'simpletags')
-        ),
-        array(
-            'auto_link_max_by_post',
-            __('Maximum number of links per article:', 'simpletags'),
-            'number',
-            'small-text',
-            __('This setting determines the maximum number of links created by article. Default: 10.', 'simpletags')
-        ),
-        array(
-            'auto_link_max_by_tag',
-            __('Maximum number of links for the same tag:', 'simpletags'),
-            'number',
-            'small-text',
-            __('This setting determines the maximum number of links created by article for the same tag. Default: 1.', 'simpletags')
-        ),
-	    array(
-		    'auto_link_all',
-		    __('Add links for unattached terms', 'simpletags'),
-		    'checkbox',
-		    '1',
-		    __('By default, TaxoPress will only add Auto Links for terms that are attached to the post. If this box is checked, TaxoPress will add links for all terms', 'simpletags')
-	    ),
-        array(
-            'auto_link_case',
-            __('Ignore case for auto link feature ?', 'simpletags'),
-            'checkbox',
-            '1',
-            __('Example: If you ignore case, auto link feature will replace the word "wordpress" by the tag link "WordPress".', 'simpletags')
-        ),
-        array(
-            'auto_link_exclude',
-            __('Exclude some terms from tag link. For Ads Link subtition, etc.', 'simpletags'),
-            'text',
-            'regular-text',
-            __('Example: If you enter the term "Paris", the auto link tags feature will never replace this term by this link.', 'simpletags')
-        ),
-        array(
-            'auto_link_priority',
-            __('Priority on hook the_content', 'simpletags'),
-            'number',
-            'small-text',
-            __('For expert, possibility to change the priority of autolinks functions on the_content hook. Useful for fix a conflict with an another plugin. Default: 12.', 'simpletags')
-        ),
-        array(
-            'auto_link_views',
-            __('Enable autolinks into post content for theses views:', 'simpletags'),
-            'radio',
-            array(
-                'no'       => __('<code>no</code> &ndash; Nowhere', 'simpletags'),
-                'all'      => __('<code>all</code> &ndash; On your blog and feeds.', 'simpletags'),
-                'single'   => __('<code>single</code> &ndash; Only on your single post view.', 'simpletags'),
-                'singular' => __('<code>singular</code> &ndash; Only on your singular view (single post & page) (default).', 'simpletags'),
-            ),
-        ),
-        array(
-            'auto_link_dom',
-            __('Try new engine replacement ?', 'simpletags'),
-            'checkbox',
-            '1',
-            __('An engine replacement alternative uses DOMDocument PHP class and theoretically offers better performance. If your server does not offer the functionality, the plugin will use the usual engine.', 'simpletags')
-        ),
-        array(
-            'auto_link_title',
-            __('Text to display into title attribute for links:', 'simpletags'),
-            'text',
-            'regular-text'
-        ),
-	    array(
-		    'auto_link_title_excl',
-		    __('Add links for post title', 'simpletags'),
-		    'checkbox',
-		    '1',
-		    __('By default, TaxoPress will exclude Auto Links for terms that are attached to the post title.', 'simpletags')
-	    ),
-    ),
+
+
     'legacy'       => array(
 
 
@@ -492,7 +405,111 @@ return array(
             '1',
             __('This feature allows you to display related posts based on terms relation.', 'simpletags'),
             'legacy-tab-content legacy-related-posts-content st-hide-content'
-        )
+        ),
+
+        
+        //auto link legacy
+        array(
+            'auto_link_tags',
+            __('Auto links tags', 'simpletags'),
+            'checkbox',
+            '1',
+            __('Example: You have a tag called "WordPress" and your post content contains "wordpress", this feature will replace "wordpress" by a link to "wordpress" tags page. (http://myblog.net/tag/wordpress/)', 'simpletags'),
+            'legacy-tab-content legacy-auto-link-content st-hide-content'
+        ),
+        array(
+            'auto_link_min',
+            __('Min usage for auto link tags:', 'simpletags'),
+            'number',
+            'small-text',
+            __('This parameter allows to fix a minimal value of use of tags. Default: 1.', 'simpletags'),
+            'legacy-tab-content legacy-auto-link-content st-hide-content'
+        ),
+        array(
+            'auto_link_max_by_post',
+            __('Maximum number of links per article:', 'simpletags'),
+            'number',
+            'small-text',
+            __('This setting determines the maximum number of links created by article. Default: 10.', 'simpletags'),
+            'legacy-tab-content legacy-auto-link-content st-hide-content'
+        ),
+        array(
+            'auto_link_max_by_tag',
+            __('Maximum number of links for the same tag:', 'simpletags'),
+            'number',
+            'small-text',
+            __('This setting determines the maximum number of links created by article for the same tag. Default: 1.', 'simpletags'),
+            'legacy-tab-content legacy-auto-link-content st-hide-content'
+        ),
+	    array(
+		    'auto_link_all',
+		    __('Add links for unattached terms', 'simpletags'),
+		    'checkbox',
+		    '1',
+		    __('By default, TaxoPress will only add Auto Links for terms that are attached to the post. If this box is checked, TaxoPress will add links for all terms', 'simpletags'),
+            'legacy-tab-content legacy-auto-link-content st-hide-content'
+	    ),
+        array(
+            'auto_link_case',
+            __('Ignore case for auto link feature ?', 'simpletags'),
+            'checkbox',
+            '1',
+            __('Example: If you ignore case, auto link feature will replace the word "wordpress" by the tag link "WordPress".', 'simpletags'),
+            'legacy-tab-content legacy-auto-link-content st-hide-content'
+        ),
+        array(
+            'auto_link_exclude',
+            __('Exclude some terms from tag link. For Ads Link subtition, etc.', 'simpletags'),
+            'text',
+            'regular-text',
+            __('Example: If you enter the term "Paris", the auto link tags feature will never replace this term by this link.', 'simpletags'),
+            'legacy-tab-content legacy-auto-link-content st-hide-content'
+        ),
+        array(
+            'auto_link_priority',
+            __('Priority on hook the_content', 'simpletags'),
+            'number',
+            'small-text',
+            __('For expert, possibility to change the priority of autolinks functions on the_content hook. Useful for fix a conflict with an another plugin. Default: 12.', 'simpletags'),
+            'legacy-tab-content legacy-auto-link-content st-hide-content'
+        ),
+        array(
+            'auto_link_views',
+            __('Enable autolinks into post content for theses views:', 'simpletags'),
+            'radio',
+            array(
+                'no'       => __('<code>no</code> &ndash; Nowhere', 'simpletags'),
+                'all'      => __('<code>all</code> &ndash; On your blog and feeds.', 'simpletags'),
+                'single'   => __('<code>single</code> &ndash; Only on your single post view.', 'simpletags'),
+                'singular' => __('<code>singular</code> &ndash; Only on your singular view (single post & page) (default).', 'simpletags'),
+            ),
+            '',
+            'legacy-tab-content legacy-auto-link-content st-hide-content'
+        ),
+        array(
+            'auto_link_dom',
+            __('Try new engine replacement ?', 'simpletags'),
+            'checkbox',
+            '1',
+            __('An engine replacement alternative uses DOMDocument PHP class and theoretically offers better performance. If your server does not offer the functionality, the plugin will use the usual engine.', 'simpletags'),
+            'legacy-tab-content legacy-auto-link-content st-hide-content'
+        ),
+        array(
+            'auto_link_title',
+            __('Text to display into title attribute for links:', 'simpletags'),
+            'text',
+            'regular-text',
+            '',
+            'legacy-tab-content legacy-auto-link-content st-hide-content'
+        ),
+	    array(
+		    'auto_link_title_excl',
+		    __('Add links for post title', 'simpletags'),
+		    'checkbox',
+		    '1',
+		    __('By default, TaxoPress will exclude Auto Links for terms that are attached to the post title.', 'simpletags'),
+            'legacy-tab-content legacy-auto-link-content st-hide-content'
+	    ),
 
 
     ),

--- a/inc/loads.php
+++ b/inc/loads.php
@@ -4,6 +4,7 @@ require STAGS_DIR . '/inc/taxonomies-functions.php'; // Taxonomy functions
 require STAGS_DIR . '/inc/tag-clouds-functions.php'; // Tag cloud functions
 require STAGS_DIR . '/inc/post-tags-functions.php'; // Post tags functions
 require STAGS_DIR . '/inc/related-posts-functions.php'; // Related posts functions
+require STAGS_DIR . '/inc/autolinks-functions.php'; // Auto links functions
 require STAGS_DIR . '/inc/functions.deprecated.php'; // Deprecated functions
 require STAGS_DIR . '/inc/functions.tpl.php';  // Templates functions
 

--- a/includes-core/TaxopressCoreAdmin.php
+++ b/includes-core/TaxopressCoreAdmin.php
@@ -24,9 +24,10 @@ class TaxopressCoreAdmin {
                                     ['base' => 'taxopress_page_st_manage',     'id'   => 'taxopress_page_st_manage'],
                                     ['base' => 'taxopress_page_st_auto',       'id'   => 'taxopress_page_st_auto'],
                                     ['base' => 'toplevel_page_st_options',     'id'   => 'toplevel_page_st_options'],
-                                    ['base' => 'taxopress_page_st_terms_display', 'id'=> 'taxopress_page_st_terms_display'],
+                                    ['base' => 'taxopress_page_st_terms_display','id' => 'taxopress_page_st_terms_display'],
                                     ['base' => 'taxopress_page_st_post_tags',   'id'  => 'taxopress_page_st_post_tags'],
-                                    ['base' => 'taxopress_page_st_related_posts', 'id'=> 'taxopress_page_st_related_posts'],
+                                    ['base' => 'taxopress_page_st_related_posts','id' => 'taxopress_page_st_related_posts'],
+                                    ['base' => 'taxopress_page_st_autolinks',   'id'  => 'taxopress_page_st_autolinks'],
                                 ]
                             ];
 

--- a/readme.txt
+++ b/readme.txt
@@ -120,7 +120,7 @@ v3.2.1- [===UNRELEASED===]
 * Autolink: New autolink UI #501
 * Autolink: Option to set autolink terms to lowercase, uppercase or retain content case #161
 * Autolink: Option to exlude autolink if the tag is already applied to the article #147
-* Autolink: Option to set minumum and maximum character length for autolink condition #132
+* Autolink: Option to set minimum and maximum character length for autolink condition #132
 * Autolink: Support for more all taxonomies #268
 * Autolink: Option to restrict Autolink instance to a post type.
 * Autolink: Option to exclude autolinks in certain classes/HTML Tags like headers, div class/id etc #160

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,17 @@ TaxoPress can be installed in 3 easy steps:
 
 == Changelog ==
 
+v3.2.1- [===UNRELEASED===]
+* Added: Autolink screen with improved features such as:
+* Autolink: New autolink UI #501
+* Autolink: Option to set autolink terms to lowercase, uppercase or retain content case #161
+* Autolink: Option to exlude autolink if the tag is already applied to the article #147
+* Autolink: Option to set minumum and maximum character length for autolink condition #132
+* Autolink: Support for more all taxonomies #268
+* Autolink: Option to restrict Autolink instance to a post type.
+* Autolink: Option to exclude autolinks in certain classes/HTML Tags like headers, div class/id etc #160
+* Deprecated: Move old Autolink settings to legacy #491
+
 v3.1.2- 2021-07-19
 * Fixed: Term display font color empty value error notification #628
 * Fixed: Improve settings success/error notification display #629

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: publishpress, kevinB, stevejburge, andergmartins, olatechpro
 Tags: tag, tags, taxonomy, term, cpt, tagging, navigation, tag manager, tags manager, term manager, terms manager
 Requires at least: 3.3
 Tested up to: 5.7
-Stable tag: 3.1.2
+Stable tag: 3.2.1
 Requires PHP: 5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/simple-tags.php
+++ b/simple-tags.php
@@ -3,7 +3,7 @@
 Plugin Name: TaxoPress
 Plugin URI: https://wordpress.org/plugins/simple-tags/
 Description: Extended Tag Manager. Terms suggestion, Mass Edit Terms, Auto link Terms, Ajax Autocompletion, Click Terms, Advanced manage terms, etc.
-Version: 3.1.2
+Version: 3.2.1
 Requires PHP: 5.6
 Requires at least: 3.3
 Tested up to: 5.6
@@ -40,7 +40,7 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('STAGS_VERSION')) {
-define('STAGS_VERSION', '3.1.2');
+define('STAGS_VERSION', '3.2.1');
 }
 
 


### PR DESCRIPTION
- [x] Move TaxoPress credit to admin footer close #712
- [x] Move old "Auto-Link" to "Legacy" close #643
- [x] Design the "Auto-Links" screen just like Terms Display / Recent Posts close #501
- [x] Autolinks: Control uppercase vs lowercase close #161
- [x] Don't add an autolink if the tag is already applied to the article close #147
- [x] Minumum length for an autolink close #132
- [x] Support for more than Tags close #268
- [x] Menu link for Auto Links close #267
- [x] exclude links in certain classes/HTML Tags close #160

@stevejburge  I end up going for tabbed page for autolinks as the page end up been long due to new feature addition and improvement, you'll have opportunity to arrange and suggest improvement to the tab after sending it for review

<img width="1140" alt="autolink-tabbed" src="https://user-images.githubusercontent.com/46832636/127867032-c6e680a1-7b80-49a4-8ad3-c156a01210ad.png">

