### PR TITLE
feature/#744-Slug_already_exists_warning_does_not_appear_if_slug_has_only_numbers_in_it,_while_creating_new_taxonomy

### DIFF
--- a/assets/js/taxonomies.js
+++ b/assets/js/taxonomies.js
@@ -316,6 +316,11 @@
         }
       });
 
+      if( $('input[name="cpt_custom_tax[name]"]').val() && !isNaN($('input[name="cpt_custom_tax[name]"]').val()) ){
+        field_error_count = 1;
+        field_error_message += '<li>' + taxopress_tax_data.integer_error + ' <span class="required">*</span></li>';
+      }
+
       if ($('.taxonomy_posttypes :checkbox:checked').length == 0) {
         field_error_count = 1;
         field_error_message += '<li>' + taxopress_tax_data.no_associated_type + ' <span class="required">*</span></li>';

--- a/inc/taxonomies.php
+++ b/inc/taxonomies.php
@@ -64,6 +64,7 @@ class SimpleTags_Admin_Taxonomies
                         'simpletags'),
                     'no_associated_type'  => esc_html__('Please select at least one post type.', 'simpletags'),
                     'existing_taxonomies' => $registered_taxonomies,
+                    'integer_error'  => esc_html__('Taxonomy slug cannot be numbers only.', 'simpletags'),
                 ]
             );
 


### PR DESCRIPTION
- "Slug already exists" warning does not appear if slug has only numbers in it, while creating new taxonomy. close #744