### PR TITLE
feature/#602-Posts_are_auto_tagged_even_when_the_content_does_not_match_the_exact_term

### DIFF
--- a/inc/class.client.autoterms.php
+++ b/inc/class.client.autoterms.php
@@ -46,7 +46,6 @@ class SimpleTags_Client_Autoterms {
 			if ( ! isset( $local_options['use_auto_terms'] ) || (int) $local_options['use_auto_terms'] != 1 ) {
 				continue;
 			}
-
 			self::auto_terms_post( $object, $taxo_name, $local_options );
 			$flag = true;
 		}
@@ -109,8 +108,8 @@ class SimpleTags_Client_Autoterms {
 
 				// Whole word ?
 				if ( isset( $options['only_full_word'] ) && (int) $options['only_full_word'] == 1 ) {
-					$preg_term = preg_quote( $term, "/" );
-					if ( preg_match( "/\b" . $preg_term . "\b/i", $content ) ) {
+					if(strpos($content, ' '.$term.' ') !== FALSE)
+					{
 						$terms_to_add[] = $term;
 					}
 
@@ -156,8 +155,8 @@ class SimpleTags_Client_Autoterms {
 
 				// Whole word ?
 				if ( isset( $options['only_full_word'] ) && (int) $options['only_full_word'] == 1 ) {
-					$preg_term = preg_quote( $term, "/" );
-					if ( preg_match( "/\b" . $preg_term . "\b/i", $content ) ) {
+					if(strpos($content, ' '.$term.' ') !== FALSE)
+					{
 						$terms_to_add[] = $term;
 					}
 

--- a/readme.txt
+++ b/readme.txt
@@ -117,6 +117,7 @@ TaxoPress can be installed in 3 easy steps:
 
 v3.3.0- [===unreleased===]
 * Fixed: Auto Links problem with " #824
+* Fixed:Posts are auto tagged even when the content does not match the exact term. #602
 
 v3.2.2- 2021-09-01
 * Fixed: Able to save mandatory field 'Title' as empty field in Terms for current post. #812


### PR DESCRIPTION
- Posts are auto tagged even when the content does not match the exact term. close #602