### PR TITLE
 feature/#792-Show_all_local_tags_does_not_display_any_tags-While_saving_the_tags_limit_with_very_large_number

### DIFF
--- a/inc/helper.options.admin.php
+++ b/inc/helper.options.admin.php
@@ -46,7 +46,7 @@ return array(
         array(
             'click_tags_limit',
             __('Click tags limit', 'simple-tags'),
-            ['type' => 'number', 'attr' => 'min="0" max=""'],
+            ['type' => 'number', 'attr' => 'min="0" max="1000"'],
             'regular-text',
             __('Click tags limit on post screen', 'simple-tags')
         ),

--- a/readme.txt
+++ b/readme.txt
@@ -118,6 +118,9 @@ TaxoPress can be installed in 3 easy steps:
 
 == Changelog ==
 
+v3.4.0- [===unreleased===]
+* Fixed: 'Show all local tags' does not display any tags, While saving the tags limit with very large number. #792
+
 v3.3.1- 2021-09-20
 * Fixed: Fatal error when deleting plugin #889
 


### PR DESCRIPTION
- 'Show all local tags' does not display any tags, While saving the tags limit with very large number. close #792