### PR TITLE
feature/#894-Autolink_tags_excludes_paragraphs_with_html_space-code

### DIFF
--- a/inc/class.client.autolinks.php
+++ b/inc/class.client.autolinks.php
@@ -300,7 +300,7 @@ class SimpleTags_Client_Autolinks {
 	/**
 	 * Replace text by link, except HTML tag, and already text into link, use DOMdocument.
 	 * https://stackoverflow.com/questions/4044812/regex-domdocument-match-and-replace-text-not-in-a-link
-	 *
+	 *  
 	 * @param string $content
 	 * @param string $search
 	 * @param string $replace
@@ -311,16 +311,17 @@ class SimpleTags_Client_Autolinks {
 	 */
 	private static function replace_by_links_dom( &$content, $search = '', $replace = '', $case = '', $rel = '', $options = false ) {
 		$dom = new DOMDocument();
-
 		$content = str_replace('&lt;','&#60;',$content);
 		$content = str_replace('&gt;','&#62;',$content);
+		$content = str_replace('&nbsp;','&#160;',$content);//https://github.com/TaxoPress/TaxoPress/issues/930
 		$content = str_replace('&#','|--|',$content);//https://github.com/TaxoPress/TaxoPress/issues/824
-        $content = str_replace('&','&#38;',$content); //https://github.com/TaxoPress/TaxoPress/issues/770
+        $content = str_replace('&','&#38;',$content); //https://github.com/TaxoPress/TaxoPress/issues/770*/
 		//$content = utf8_decode($content);
 
         libxml_use_internal_errors(true);
 		// loadXml needs properly formatted documents, so it's better to use loadHtml, but it needs a hack to properly handle UTF-8 encoding
 		$result = $dom->loadHtml( mb_convert_encoding( $content, 'HTML-ENTITIES', "UTF-8" ) );
+
 		if ( false === $result ) {
 			return;
 		}
@@ -423,6 +424,7 @@ class SimpleTags_Client_Autolinks {
 		$content = str_replace('|--|','&#',$content);//https://github.com/TaxoPress/TaxoPress/issues/824
 		$content = str_replace('&#60;','<',$content);
 		$content = str_replace('&#62;','>',$content);
+		$content = str_replace('&#160;','&nbsp;',$content);//https://github.com/TaxoPress/TaxoPress/issues/930
         $content = str_replace('&#38;','&',$content); //https://github.com/TaxoPress/TaxoPress/issues/770
         $content = str_replace(';amp;',';',$content); //https://github.com/TaxoPress/TaxoPress/issues/810
 		

--- a/readme.txt
+++ b/readme.txt
@@ -122,6 +122,7 @@ v3.4.0- [===unreleased===]
 * Fixed: 'Show all local tags' does not display any tags, While saving the tags limit with very large number. #792
 * Added: Auto Terms limit in settings #450
 * Added: Allow users to choose any taxonomy, ordering and number of items in "Click Tags" #497
+* Fixed: Autolink tags excludes paragraphs with html space-code #894
 
 
 v3.3.1- 2021-09-20


### PR DESCRIPTION
- Autolink tags excludes paragraphs with html space-code close #894