### PR TITLE
feature/#1227_Save_button_missing_on_Mass_Edit_Terms 

### DIFF
--- a/inc/class.admin.mass.php
+++ b/inc/class.admin.mass.php
@@ -277,7 +277,7 @@ class SimpleTags_Admin_Mass {
 						<input type="hidden" name="secure_mass"
 						       value="<?php echo esc_attr(wp_create_nonce( 'st_mass_terms' )); ?>"/>
 						<input class="button-primary" type="submit" name="update_mass"
-						       value="<?php esc_attr( 'Update all &raquo;', 'simple-tags' ); ?>"/>
+						       value="<?php esc_attr_e( 'Update all &raquo;', 'simple-tags' ); ?>"/>
 					</p>
 				</form>
 


### PR DESCRIPTION
- "Save" button missing on Mass Edit Terms fix #1227