### PR TITLE
feature/#1674_Add_a_synonyms_option_for_Auto_Terms

### DIFF
--- a/inc/autoterms-functions.php
+++ b/inc/autoterms-functions.php
@@ -221,6 +221,7 @@ function taxopress_create_default_autoterm()
                     $default['taxopress_autoterm']['autoterm_hash']            = isset($options_taxonomy_data['allow_hashtag_format']) ? $options_taxonomy_data['allow_hashtag_format'] : 0;
                     $default['specific_terms']            = isset($options_taxonomy_data['auto_list']) ? (array) maybe_unserialize($options_taxonomy_data['auto_list']) : [];
                     $default['taxopress_autoterm']['terms_limit']              = '0';
+                    $default['taxopress_autoterm']['synonyms_term']            = '0';
 
                     $result                                                    = taxopress_update_autoterm($default);
                 }
@@ -242,6 +243,7 @@ function taxopress_create_default_autoterm()
         $default['taxopress_autoterm']['autoterm_word']            = '0';
         $default['taxopress_autoterm']['autoterm_hash']            = '0';
         $default['taxopress_autoterm']['terms_limit']              = '0';
+        $default['taxopress_autoterm']['synonyms_term']            = '0';
         $default['specific_terms']                                  = [];
         $result                                                    = taxopress_update_autoterm($default);
     }
@@ -305,6 +307,9 @@ function taxopress_update_autoterm($data = [])
     }
     if (!isset($data['taxopress_autoterm']['autoterm_hash'])) {
         $data['taxopress_autoterm']['autoterm_hash'] = 0;
+    }
+    if (!isset($data['taxopress_autoterm']['synonyms_term'])) {
+        $data['taxopress_autoterm']['synonyms_term'] = 0;
     }
 
     if (isset($data['edited_autoterm'])) {

--- a/inc/autoterms.php
+++ b/inc/autoterms.php
@@ -726,6 +726,24 @@ class SimpleTags_Autoterms
                                                 <table class="form-table taxopress-table autoterm_options"
                                                        style="<?php echo $active_tab === 'autoterm_options' ? '' : 'display:none;'; ?>">
                                                     <?php
+
+                                                    $selected           = (isset($current) && isset($current['synonyms_term'])) ? taxopress_disp_boolean($current['synonyms_term']) : '';
+                                                    $select['selected'] = !empty($selected) ? $current['synonyms_term'] : '';
+                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    echo $ui->get_select_checkbox_input([
+                                                        'namearray'  => 'taxopress_autoterm',
+                                                        'name'       => 'synonyms_term',
+                                                        'labeltext'  => esc_html__(
+                                                            'Add terms if synonyms found',
+                                                            'simple-tags'
+                                                        ),
+                                                        'aftertext'  => esc_html__(
+                                                            'TaxoPress will add a term to the post if a synonym is found.',
+                                                            'simple-tags'
+                                                        ),
+                                                        'selections' => $select, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    ]);
+                                                    
                                                     // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
                                                     echo $ui->get_number_input([
                                                         'namearray' => 'taxopress_autoterm',

--- a/inc/class.client.autoterms.php
+++ b/inc/class.client.autoterms.php
@@ -26,7 +26,6 @@ class SimpleTags_Client_Autoterms
 	 */
 	public static function save_post($post_id = null, $object = null)
 	{
-
 		// Get options
 		$options = get_option(STAGS_OPTIONS_NAME_AUTO);
 
@@ -49,13 +48,14 @@ class SimpleTags_Client_Autoterms
 		$current_post_status = $object->post_status;
 		$autoterms = taxopress_get_autoterm_data();
 		$flag = false;
-		foreach ($autoterms as $autoterm_key => $autoterm_data) {
+
+		foreach ($autoterms as $autoterm_data) {
 			$eligible_post_status = isset($autoterm_data['post_status']) && is_array($autoterm_data['post_status']) ? $autoterm_data['post_status'] : ['publish'];
 			$eligible_post_types = isset($autoterm_data['post_types']) && is_array($autoterm_data['post_types']) ? $autoterm_data['post_types'] : [];
 			$eligible_post_types = array_filter($eligible_post_types);
 
 			if (count($eligible_post_types) === 0) {
-				break;
+				continue;
 			}
 			if (!in_array($current_post_type, $eligible_post_types)) {
 				continue;
@@ -187,15 +187,16 @@ class SimpleTags_Client_Autoterms
 						//add primary term
 						$add_terms = [];
 						$add_terms[$term] = $term;
-
 						// add term synonyms
-						$add_terms_object = get_term_by('name', esc_attr($term), $taxonomy);
-						if (is_object($add_terms_object) && isset($add_terms_object->term_id)) {
-							$term_synonyms = (array) get_term_meta($add_terms_object->term_id, '_taxopress_term_synonyms', true);
-							$term_synonyms = array_filter($term_synonyms);
-							if (!empty($term_synonyms)) {
-								foreach ($term_synonyms as $term_synonym) {
-									$add_terms[$term_synonym] = $term;
+						if (is_array($options) && isset($options['synonyms_term']) && (int)$options['synonyms_term'] > 0) {
+							$add_terms_object = get_term_by('name', esc_attr($term), $taxonomy);
+							if (is_object($add_terms_object) && isset($add_terms_object->term_id)) {
+								$term_synonyms = (array) get_term_meta($add_terms_object->term_id, '_taxopress_term_synonyms', true);
+								$term_synonyms = array_filter($term_synonyms);
+								if (!empty($term_synonyms)) {
+									foreach ($term_synonyms as $term_synonym) {
+										$add_terms[$term_synonym] = $term;
+									}
 								}
 							}
 						}
@@ -286,13 +287,15 @@ class SimpleTags_Client_Autoterms
 						$add_terms[$term] = $term;
 
 						// add term synonyms
-						$add_terms_object = get_term_by('name', esc_attr($term), $taxonomy);
-						if (is_object($add_terms_object) && isset($add_terms_object->term_id)) {
-							$term_synonyms = (array) get_term_meta($add_terms_object->term_id, '_taxopress_term_synonyms', true);
-							$term_synonyms = array_filter($term_synonyms);
-							if (!empty($term_synonyms)) {
-								foreach ($term_synonyms as $term_synonym) {
-									$add_terms[$term_synonym] = $term;
+						if (is_array($options) && isset($options['synonyms_term']) && (int)$options['synonyms_term'] > 0) {
+							$add_terms_object = get_term_by('name', esc_attr($term), $taxonomy);
+							if (is_object($add_terms_object) && isset($add_terms_object->term_id)) {
+								$term_synonyms = (array) get_term_meta($add_terms_object->term_id, '_taxopress_term_synonyms', true);
+								$term_synonyms = array_filter($term_synonyms);
+								if (!empty($term_synonyms)) {
+									foreach ($term_synonyms as $term_synonym) {
+										$add_terms[$term_synonym] = $term;
+									}
 								}
 							}
 						}
@@ -354,13 +357,15 @@ class SimpleTags_Client_Autoterms
 				$add_terms[$term] = $term;
 
 				// add term synonyms
-				$add_terms_object = get_term_by('name', esc_attr($term), $taxonomy);
-				if (is_object($add_terms_object) && isset($add_terms_object->term_id)) {
-					$term_synonyms = (array) get_term_meta($add_terms_object->term_id, '_taxopress_term_synonyms', true);
-					$term_synonyms = array_filter($term_synonyms);
-					if (!empty($term_synonyms)) {
-						foreach ($term_synonyms as $term_synonym) {
-							$add_terms[$term_synonym] = $term;
+				if (is_array($options) && isset($options['synonyms_term']) && (int)$options['synonyms_term'] > 0) {
+					$add_terms_object = get_term_by('name', esc_attr($term), $taxonomy);
+					if (is_object($add_terms_object) && isset($add_terms_object->term_id)) {
+						$term_synonyms = (array) get_term_meta($add_terms_object->term_id, '_taxopress_term_synonyms', true);
+						$term_synonyms = array_filter($term_synonyms);
+						if (!empty($term_synonyms)) {
+							foreach ($term_synonyms as $term_synonym) {
+								$add_terms[$term_synonym] = $term;
+							}
 						}
 					}
 				}
@@ -429,13 +434,15 @@ class SimpleTags_Client_Autoterms
 				$add_terms[$term] = $term;
 
 				// add term synonyms
-				$add_terms_object = get_term_by('name', esc_attr($term), $taxonomy);
-				if (is_object($add_terms_object) && isset($add_terms_object->term_id)) {
-					$term_synonyms = (array) get_term_meta($add_terms_object->term_id, '_taxopress_term_synonyms', true);
-					$term_synonyms = array_filter($term_synonyms);
-					if (!empty($term_synonyms)) {
-						foreach ($term_synonyms as $term_synonym) {
-							$add_terms[$term_synonym] = $term;
+				if (is_array($options) && isset($options['synonyms_term']) && (int)$options['synonyms_term'] > 0) {
+					$add_terms_object = get_term_by('name', esc_attr($term), $taxonomy);
+					if (is_object($add_terms_object) && isset($add_terms_object->term_id)) {
+						$term_synonyms = (array) get_term_meta($add_terms_object->term_id, '_taxopress_term_synonyms', true);
+						$term_synonyms = array_filter($term_synonyms);
+						if (!empty($term_synonyms)) {
+							foreach ($term_synonyms as $term_synonym) {
+								$add_terms[$term_synonym] = $term;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
<!--
  Hey, that's awesome! Thanks for your interest and for taking the time to contribute.
  The following is a set of guidelines for contributing to PublishPress Authors plugin. Use your best judgment, and feel free to propose changes to this document in a pull request. 
  
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
  
  Please, review the guidelines for contributing to this repository:
  
  https://github.com/publishpress/PublishPress-Authors/blob/development/CONTRIBUTING.md
 -->

## Description
<!-- We must be able to understand the design of your change from this description. -->
 - Add a synonyms option for Auto Terms #1674

## Benefits
<!-- What benefits will be realized the code changes? -->
fixes https://github.com/TaxoPress/TaxoPress/issues/1674

## Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->

## Applicable issues
<!-- Link any applicable Issues here -->

## Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [x] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
