### PR TITLE
feature/#1859_Terms_not_displayed_when_using_DESC_ordering_with_numerical_terms

### DIFF
--- a/inc/class.client.tagcloud.php
+++ b/inc/class.client.tagcloud.php
@@ -230,7 +230,7 @@ class SimpleTags_Client_TagCloud {
 
 		$order = strtolower( $order );
 		if ( $order == 'desc' && $orderby != 'random' ) {
-			$counts = array_reverse( $counts );
+			$counts = array_reverse( $counts, true );
 		}
 
 		$output = array();


### PR DESCRIPTION
- Terms not displayed when using DESC ordering with numerical terms fix #1859