### PR TITLE
Bugfix: The term_id is used to update the row where term_taxonomy_id = term_id

### DIFF
--- a/inc/terms.php
+++ b/inc/terms.php
@@ -118,7 +118,7 @@ class SimpleTags_Terms
                     $update_term = $wpdb->update(
                         $wpdb->prefix . 'term_taxonomy',
                         ['taxonomy' => $edit_taxonomy],
-                        ['term_id' => $tag->term_id, 'taxonomy' => $taxonomy],
+                        ['term_taxonomy_id' => $tag->term_taxonomy_id],
                         ['%s'],
                         ['%d', '%s']
                     );

--- a/inc/terms.php
+++ b/inc/terms.php
@@ -118,7 +118,7 @@ class SimpleTags_Terms
                     $update_term = $wpdb->update(
                         $wpdb->prefix . 'term_taxonomy',
                         ['taxonomy' => $edit_taxonomy],
-                        ['term_taxonomy_id' => $tag->term_id],
+                        ['term_id' => $tag->term_id],
                         ['%s'],
                         ['%d']
                     );

--- a/inc/terms.php
+++ b/inc/terms.php
@@ -124,7 +124,7 @@ class SimpleTags_Terms
                     );
                     if ($update_term) {
                         clean_term_cache($tag->term_id);
-                        $tag = get_term($tag->term_id);
+                        $tag = get_term($tag->term_id, $edit_taxonomy);
                     }
                 }
             }

--- a/inc/terms.php
+++ b/inc/terms.php
@@ -118,9 +118,9 @@ class SimpleTags_Terms
                     $update_term = $wpdb->update(
                         $wpdb->prefix . 'term_taxonomy',
                         ['taxonomy' => $edit_taxonomy],
-                        ['term_id' => $tag->term_id],
+                        ['term_id' => $tag->term_id, 'taxonomy' => $taxonomy],
                         ['%s'],
-                        ['%d']
+                        ['%d', '%s']
                     );
                     if ($update_term) {
                         clean_term_cache($tag->term_id);

--- a/inc/terms.php
+++ b/inc/terms.php
@@ -120,7 +120,7 @@ class SimpleTags_Terms
                         ['taxonomy' => $edit_taxonomy],
                         ['term_taxonomy_id' => $tag->term_taxonomy_id],
                         ['%s'],
-                        ['%d', '%s']
+                        ['%d']
                     );
                     if ($update_term) {
                         clean_term_cache($tag->term_id);


### PR DESCRIPTION
## Description
When switching a term from a taxonomy to another, the term_id is used to update the row where term_taxonomy_id = term_id resulting in random switching of terms.

## Benefits
It updates the right term to the right taxonomy

## Possible drawbacks
None, this is a bug.

## Applicable issues


## Checklist

- [X] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [X] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [X] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [X] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [X] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
