### PR TITLE
feature/#2070_Mass_Edit_Terms_is_broken_by_the_WordPress_update_notice 

### DIFF
--- a/inc/class.admin.manage.php
+++ b/inc/class.admin.manage.php
@@ -126,6 +126,7 @@ class SimpleTags_Admin_Manage
 
         settings_errors(__CLASS__); ?>
 <div class="clear"></div>
+<div class="taxopress-block-wrap">
 <div class="wrap st_wrap tagcloudui st-manage-terms-page admin-settings wrap st_wrap">
 	<?php SimpleTags_Admin::boxSelectorTaxonomy('st_manage'); ?>
 
@@ -391,6 +392,7 @@ class SimpleTags_Admin_Manage
 	<?php do_action('taxopress_admin_after_sidebar'); ?>
 </div>
 
+</div>
 
 
 	<?php SimpleTags_Admin::printAdminFooter(); ?>

--- a/inc/class.admin.mass.php
+++ b/inc/class.admin.mass.php
@@ -104,6 +104,7 @@ class SimpleTags_Admin_Mass {
 		// Display message
 		settings_errors( __CLASS__ );
 		?>
+		<div class="taxopress-block-wrap">
 		<div class="wrap st_wrap tagcloudui st_mass_terms-page admin-settings">
 			<form id="posts-filter" action="" method="get">
 				<input type="hidden" name="page" value="st_mass_terms"/>
@@ -290,6 +291,8 @@ class SimpleTags_Admin_Mass {
 
 		<div class="taxopress-right-sidebar admin-settings-sidebar">
 			<?php do_action('taxopress_admin_after_sidebar'); ?>
+		</div>
+		
 		</div>
 
 		<?php

--- a/inc/dashboard.php
+++ b/inc/dashboard.php
@@ -90,7 +90,7 @@ class SimpleTags_Dashboard
             </div>
         </div>
     <?php endif; ?>
-
+    <div class="taxopress-block-wrap">
         <div class="wrap st_wrap tagcloudui st_dashboard-page admin-settings">
             <h1 class="wp-heading-inline"><?php esc_html_e('Dashboard', 'simple-tags'); ?></h1>
             <div class="taxopress-description">
@@ -121,6 +121,8 @@ class SimpleTags_Dashboard
 
         <div class="taxopress-right-sidebar admin-settings-sidebar">
             <?php do_action('taxopress_admin_after_sidebar'); ?>
+        </div>
+
         </div>
 
 <?php

--- a/views/admin/page-settings.php
+++ b/views/admin/page-settings.php
@@ -1,3 +1,4 @@
+<div class="taxopress-block-wrap">
 <div class="wrap st_wrap tagcloudui admin-settings">
 	<div id="icon-themes" class="icon32"><br></div>
 	<h2><?php _e( 'TaxoPress: Options', 'simple-tags' ); ?></h2>
@@ -49,4 +50,5 @@
 
 <div class="taxopress-right-sidebar admin-settings-sidebar">
 	<?php do_action('taxopress_admin_after_sidebar'); ?>
+</div>
 </div>


### PR DESCRIPTION
Mass Edit Terms is broken by the WordPress update notice fix #2070