### PR TITLE
update/#2133-Make-Auto-Links-run-early-before-other-the_content-filter

### DIFF
--- a/inc/class.client.autolinks.php
+++ b/inc/class.client.autolinks.php
@@ -27,8 +27,8 @@ class SimpleTags_Client_Autolinks
 			add_filter('the_posts', array(__CLASS__, 'the_posts'), 10);
 
 			//new UI
-			add_filter('the_content', array(__CLASS__, 'taxopress_autolinks_the_content'), 12);
-			add_filter('the_title', array(__CLASS__, 'taxopress_autolinks_the_title'), 12);
+			add_filter('the_content', array(__CLASS__, 'taxopress_autolinks_the_content'), 5);
+			add_filter('the_title', array(__CLASS__, 'taxopress_autolinks_the_title'), 5);
 		}
 	}
 


### PR DESCRIPTION
Make Auto Links run early before other the_content filter fix #2133 fix https://github.com/TaxoPress/TaxoPress/issues/2121