### PR TITLE
fix/#2281-Existing-Content-Limit-Auto-Terms-based-on-published-date-always-defaults-to-24-hours-ago 

### DIFF
--- a/inc/autoterms_content.php
+++ b/inc/autoterms_content.php
@@ -81,7 +81,7 @@ class SimpleTags_Autoterms_Content
 
             $existing_terms_batches = !empty($_POST['taxopress_autoterm_content']['existing_terms_batches']) ? (int)$_POST['taxopress_autoterm_content']['existing_terms_batches'] : 0;
             $existing_terms_sleep = !empty($_POST['taxopress_autoterm_content']['existing_terms_sleep']) ? (int)$_POST['taxopress_autoterm_content']['existing_terms_sleep'] : 0;
-            $limit_days = !empty($_POST['taxopress_autoterm_content']['limit_days']) ? (int)$_POST['taxopress_autoterm_content']['limit_days'] : 0;
+            $limit_days = !empty($_POST['taxopress_autoterm_content']['limit_days']) ? taxopress_sanitize_text_field($_POST['taxopress_autoterm_content']['limit_days']) : 0;
             $autoterm_existing_content_exclude = !empty($_POST['taxopress_autoterm_content']['autoterm_existing_content_exclude']) ? (int)$_POST['taxopress_autoterm_content']['autoterm_existing_content_exclude'] : 0;
 
             $response_message = esc_html__('An error occured.', 'simple-tags');


### PR DESCRIPTION
Existing Content "Limit Auto Terms, based on published date" always defaults to "24 hours ago" fix #2281