### PR TITLE
Autofix: Text change for Related Posts option

### DIFF
--- a/inc/related-posts.php
+++ b/inc/related-posts.php
@@ -648,8 +648,23 @@ class SimpleTags_Related_Post
                                                             // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
                                                             echo $ui->get_text_input([
                                                                 'namearray' => 'taxopress_related_post',
+                                                                'name'      => 'before_list',
+                                                                'textvalue' => isset($current['before_list']) ? esc_attr($current['before_list']) : '',
+                                                                'labeltext' => esc_html__('Text before related posts list', 'simple-tags'),
+                                                                'helptext'  => esc_html__('Enter the text to display before the related posts list.', 'simple-tags'),
+                                                                'required'  => false,
+                                                            ]);
                                                                 'name'      => 'before',
                                                                 'textvalue' => isset($current['before']) ? esc_attr($current['before']) : '',
+                                                            // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                            echo $ui->get_text_input([
+                                                                'namearray' => 'taxopress_related_post',
+                                                                'name'      => 'after_list',
+                                                                'textvalue' => isset($current['after_list']) ? esc_attr($current['after_list']) : '',
+                                                                'labeltext' => esc_html__('Text after related posts list', 'simple-tags'),
+                                                                'helptext'  => esc_html__('Enter the text to display after the related posts list.', 'simple-tags'),
+                                                                'required'  => false,
+                                                            ]);
                                                                 'labeltext' => esc_html__(
                                                                     'Text to display before posts list',
                                                                     'simple-tags'


### PR DESCRIPTION
Add two new text input fields in the 'General' tab for entering text to display before and after the related posts list. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    