### PR TITLE
update/#2200-Add-a-new-tab-When-to-Use-and-move-applicable-settings-to-each-subtabs 

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1075,6 +1075,7 @@ ul.taxopress-tab {
     background-color: #fafafa;
     border-right: 1px solid #eee;
     box-sizing: border-box;
+    min-height: 400px;
 }
 .taxopress-tab-content {
     float: left;
@@ -1155,6 +1156,9 @@ ul.taxopress-tab li.autolink_control_tab a::before {
 
 ul.taxopress-tab li.autoterm_terms_tab a::before {
     content: "\f323";
+}
+ul.taxopress-tab li.autoterm_when_to_use_tab a::before {
+    content: "\f506";
 }
 ul.taxopress-tab li.autoterm_options_tab a::before {
     content: "\f180";

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1359,28 +1359,28 @@
     //   Auto term source to only change
     // -------------------------------------------------------------
     $(document).on('change', '.autoterm-terms-to-use-field', function (e) {
-      hide_show_tab_group_fields();
+      hide_show_source_tab_group_fields();
     })
 
     // -------------------------------------------------------------
-    //   Button group click
+    //   Button group(source tab) click
     // -------------------------------------------------------------
-    if ($('.taxopress-group-wrap.autoterm-tab-group').length > 0) {
-      hide_show_tab_group_fields();
+    if ($('.taxopress-group-wrap.autoterm-tab-group.source').length > 0) {
+      hide_show_source_tab_group_fields();
     }
-    $(document).on("click", ".taxopress-button-group label", function () {
+    $(document).on("click", ".taxopress-group-wrap.autoterm-tab-group.source label", function () {
       var current_button = $(this);
-      var button_group   = current_button.closest('.taxopress-button-group');
+      var button_group   = current_button.closest('.taxopress-group-wrap.autoterm-tab-group.source');
       //remove active class
       button_group.find('label').removeClass('current');
       //add active class to current select
       current_button.addClass('current');
       current_button.addClass('selected');
       // show/hide group based on selected fields
-      hide_show_tab_group_fields();
+      hide_show_source_tab_group_fields();
     });
 
-    function hide_show_tab_group_fields() {
+    function hide_show_source_tab_group_fields() {
       var tabs = [
         'existing',
         'openai',
@@ -1391,22 +1391,22 @@
 
       tabs.forEach(function(tab) {
         if ($('.fields-control.autoterm-terms-use-' + tab + ':checked').length > 0) {
-          $('.taxopress-button-group label.' + tab).addClass('selected');
-          $('.taxopress-button-group label.' + tab + ' input').prop('checked', true);
+          $('.taxopress-group-wrap.autoterm-tab-group.source label.' + tab).addClass('selected');
+          $('.taxopress-group-wrap.autoterm-tab-group.source label.' + tab + ' input').prop('checked', true);
           $('.autoterm-terms-use-' + tab + ':not(.fields-control)').closest('tr').removeClass('st-hide-content');
         } else {
-          $('.taxopress-button-group label.' + tab).removeClass('selected');
-          $('.taxopress-button-group label.' + tab + ' input').prop('checked', false);
+          $('.taxopress-group-wrap.autoterm-tab-group.source label.' + tab).removeClass('selected');
+          $('.taxopress-group-wrap.autoterm-tab-group.source label.' + tab + ' input').prop('checked', false);
           $('.autoterm-terms-use-' + tab + ':not(.fields-control)').closest('tr').addClass('st-hide-content');
         }
 
         // show/hide all current tab fields
-        if ($('.taxopress-group-wrap.autoterm-tab-group label.' + tab).hasClass("current")) {
+        if ($('.taxopress-group-wrap.autoterm-tab-group.source label.' + tab).hasClass("current")) {
           $('.autoterm-terms-use-' + tab).closest('tr').removeClass('st-hide-content');
           // conditional show/hide tab fields if main field is checked
           if ($('.fields-control.autoterm-terms-use-' + tab + ':checked').length > 0) {
-            $('.taxopress-button-group label.' + tab).addClass('selected');
-            $('.taxopress-button-group label.' + tab + ' input').prop('checked', true);
+            $('.taxopress-group-wrap.autoterm-tab-group.source label.' + tab).addClass('selected');
+            $('.taxopress-group-wrap.autoterm-tab-group.source label.' + tab + ' input').prop('checked', true);
             $('.autoterm-terms-use-' + tab + ':not(.fields-control)').closest('tr').removeClass('st-hide-content');
             // show or hide autoterm_use_taxonomy sub field
             if ($('.fields-control.autoterm-terms-use-' + tab + ':checked').hasClass('autoterm_use_taxonomy')) {
@@ -1418,8 +1418,8 @@
                 }
             }
           } else {
-            $('.taxopress-button-group label.' + tab).removeClass('selected');
-            $('.taxopress-button-group label.' + tab + ' input').prop('checked', false);
+            $('.taxopress-group-wrap.autoterm-tab-group.source label.' + tab).removeClass('selected');
+            $('.taxopress-group-wrap.autoterm-tab-group.source label.' + tab + ' input').prop('checked', false);
             $('.autoterm-terms-use-' + tab + ':not(.fields-control)').closest('tr').addClass('st-hide-content');
           }
           // make sure notice/description always show even if control is not checked
@@ -1427,6 +1427,83 @@
         } else {
           $('.autoterm-terms-use-' + tab).closest('tr').addClass('st-hide-content');
           $('.autoterm-terms-use-' + tab + '-notice').closest('tr').addClass('st-hide-content');
+        }
+      });
+      // re-adjust the height
+      $('ul.taxopress-tab li.autoterm_terms_tab.active').trigger('click');
+    }
+
+    // -------------------------------------------------------------
+    //   Auto term when to only change
+    // -------------------------------------------------------------
+    $(document).on('change', '.autoterm-terms-when-to-field', function (e) {
+      hide_show_when_tab_group_fields();
+    })
+
+    // -------------------------------------------------------------
+    //   Button group(when tab) click
+    // -------------------------------------------------------------
+    if ($('.taxopress-group-wrap.autoterm-tab-group.when').length > 0) {
+      hide_show_when_tab_group_fields();
+    }
+    $(document).on("click", ".taxopress-group-wrap.autoterm-tab-group.when label", function () {
+      var current_button = $(this);
+      var button_group   = current_button.closest('.taxopress-group-wrap.autoterm-tab-group.when');
+      //remove active class
+      button_group.find('label').removeClass('current');
+      //add active class to current select
+      current_button.addClass('current');
+      current_button.addClass('selected');
+      // show/hide group based on selected fields
+      hide_show_when_tab_group_fields();
+    });
+
+    function hide_show_when_tab_group_fields() {
+      var tabs = [
+        'post',
+        'schedule',
+        'existing-content',
+        'metaboxes'
+      ];
+
+      tabs.forEach(function(tab) {
+        if ($('.fields-control.autoterm-terms-when-' + tab + ':checked').length > 0) {
+          $('.taxopress-group-wrap.autoterm-tab-group.when label.' + tab).addClass('selected');
+          $('.taxopress-group-wrap.autoterm-tab-group.when label.' + tab + ' input').prop('checked', true);
+          $('.autoterm-terms-when-' + tab + ':not(.fields-control)').closest('tr').removeClass('st-hide-content');
+        } else {
+          $('.taxopress-group-wrap.autoterm-tab-group.when label.' + tab).removeClass('selected');
+          $('.taxopress-group-wrap.autoterm-tab-group.when label.' + tab + ' input').prop('checked', false);
+          $('.autoterm-terms-when-' + tab + ':not(.fields-control)').closest('tr').addClass('st-hide-content');
+        }
+
+        // show/hide all current tab fields
+        if ($('.taxopress-group-wrap.autoterm-tab-group.when label.' + tab).hasClass("current")) {
+          $('.autoterm-terms-when-' + tab).closest('tr').removeClass('st-hide-content');
+          // conditional show/hide tab fields if main field is checked
+          if ($('.fields-control.autoterm-terms-when-' + tab + ':checked').length > 0) {
+            $('.taxopress-group-wrap.autoterm-tab-group.when label.' + tab).addClass('selected');
+            $('.taxopress-group-wrap.autoterm-tab-group.when label.' + tab + ' input').prop('checked', true);
+            $('.autoterm-terms-when-' + tab + ':not(.fields-control)').closest('tr').removeClass('st-hide-content');
+            // show or hide autoterm_use_taxonomy sub field
+            if ($('.fields-control.autoterm-terms-when-' + tab + ':checked').hasClass('autoterm_use_taxonomy')) {
+              $('.autoterm_useall').closest('tr').removeClass('st-hide-content');
+                $('.autoterm_useonly').closest('tr').removeClass('st-hide-content');
+                if(!$('.autoterm_useonly').prop('checked')){
+                  $('.autoterm_useall').prop('checked', true);
+                  $('.autoterm_useonly_options').addClass('st-hide-content');
+                }
+            }
+          } else {
+            $('.taxopress-group-wrap.autoterm-tab-group.when label.' + tab).removeClass('selected');
+            $('.taxopress-group-wrap.autoterm-tab-group.when label.' + tab + ' input').prop('checked', false);
+            $('.autoterm-terms-when-' + tab + ':not(.fields-control)').closest('tr').addClass('st-hide-content');
+          }
+          // make sure notice/description always show even if control is not checked
+          $('.autoterm-terms-when-' + tab + '-notice').closest('tr').removeClass('st-hide-content');
+        } else {
+          $('.autoterm-terms-when-' + tab).closest('tr').addClass('st-hide-content');
+          $('.autoterm-terms-when-' + tab + '-notice').closest('tr').addClass('st-hide-content');
         }
       });
       // re-adjust the height

--- a/inc/ajax-request.php
+++ b/inc/ajax-request.php
@@ -74,6 +74,11 @@ function taxopress_autoterms_content_by_ajax()
             wp_send_json($response);
         }
 
+        if (empty($autoterm_data['autoterm_for_existing_content'])) {
+            $response['message'] = '<div class="taxopress-response-css red"><p>'. esc_html__('The selected Auto Term is not enabled for existing content. Please enable it in Auto Term settings.', 'simple-tags') .'</p><button type="button" class="notice-dismiss"></button></div>';
+            wp_send_json($response);
+        }
+
         $limit = (isset($autoterm_data['existing_terms_batches']) && (int)$autoterm_data['existing_terms_batches'] > 0) ? (int)$autoterm_data['existing_terms_batches'] : 20;
 
         $sleep = (isset($autoterm_data['existing_terms_sleep']) && (int)$autoterm_data['existing_terms_sleep'] > 0) ? (int)$autoterm_data['existing_terms_sleep'] : 0;

--- a/inc/autoterms-functions.php
+++ b/inc/autoterms-functions.php
@@ -290,6 +290,14 @@ function taxopress_create_default_autoterm()
         $default['taxopress_autoterm']['autoterm_hash']            = '0';
         $default['taxopress_autoterm']['terms_limit']              = '5';
         $default['taxopress_autoterm']['synonyms_term']            = '0';
+        $default['taxopress_autoterm']['autoterm_for_post']        = '1';
+        $default['taxopress_autoterm']['autoterm_for_schedule']    = '1';
+        $default['taxopress_autoterm']['autoterm_for_existing_content'] = '1';
+        $default['taxopress_autoterm']['autoterm_for_metaboxes']    = '1';
+        $default['taxopress_autoterm']['schedule_terms_limit']      = '5';
+        $default['taxopress_autoterm']['schedule_autoterm_target']  = '0';
+        $default['taxopress_autoterm']['schedule_autoterm_word']    = '0';
+        $default['taxopress_autoterm']['schedule_autoterm_hash']    = '0';
         $default['specific_terms']                                  = [];
         $default['find_in_customs_entries']                         = [];
         $default['find_in_custom_fields_custom_items']              = [];
@@ -377,6 +385,27 @@ function taxopress_update_autoterm($data = [])
     }
     if (!isset($data['taxopress_autoterm']['synonyms_term'])) {
         $data['taxopress_autoterm']['synonyms_term'] = 0;
+    }
+    if (!isset($data['taxopress_autoterm']['autoterm_for_post'])) {
+        $data['taxopress_autoterm']['autoterm_for_post'] = 0;
+    }
+    if (!isset($data['taxopress_autoterm']['autoterm_for_schedule'])) {
+        $data['taxopress_autoterm']['autoterm_for_schedule'] = 0;
+    }
+    if (!isset($data['taxopress_autoterm']['autoterm_for_existing_content'])) {
+        $data['taxopress_autoterm']['autoterm_for_existing_content'] = 0;
+    }
+    if (!isset($data['taxopress_autoterm']['autoterm_for_metaboxes'])) {
+        $data['taxopress_autoterm']['autoterm_for_metaboxes'] = 0;
+    }
+    if (!isset($data['taxopress_autoterm']['schedule_autoterm_target'])) {
+        $data['taxopress_autoterm']['schedule_autoterm_target'] = 0;
+    }
+    if (!isset($data['taxopress_autoterm']['schedule_autoterm_word'])) {
+            $data['taxopress_autoterm']['schedule_autoterm_word'] = 0;
+    }
+    if (!isset($data['taxopress_autoterm']['schedule_autoterm_hash'])) {
+        $data['taxopress_autoterm']['schedule_autoterm_hash'] = 0;
     }
 
     if (isset($data['edited_autoterm'])) {

--- a/inc/autoterms.php
+++ b/inc/autoterms.php
@@ -408,6 +408,11 @@ class SimpleTags_Autoterms
                                                                 'simple-tags'); ?></span></a>
                                                 </li>
 
+                                                <li aria-current="<?php echo $active_tab === 'autoterm_when_to_use' ? 'true' : 'false'; ?>" class="autoterm_when_to_use_tab <?php echo $active_tab === 'autoterm_when_to_use' ? 'active' : ''; ?>" data-content="autoterm_when_to_use">
+                                                    <a href="#autoterm_when_to_use"><span><?php esc_html_e('When to Use',
+                                                                'simple-tags'); ?></span></a>
+                                                </li>
+
                                                 <li aria-current="<?php echo $active_tab === 'autoterm_options' ? 'true' : 'false'; ?>" class="autoterm_options_tab <?php echo $active_tab === 'autoterm_options' ? 'active' : ''; ?>" data-content="autoterm_options">
                                                     <a href="#autoterm_options"><span><?php esc_html_e('Options',
                                                                 'simple-tags'); ?></span></a>
@@ -695,12 +700,238 @@ class SimpleTags_Autoterms
 
 
 
+                                                <table class="form-table taxopress-table autoterm_when_to_use"
+                                                       style="<?php echo $active_tab === 'autoterm_when_to_use' ? '' : 'display:none;'; ?>">
+                                                    <tr valign="top" class="tab-group-tr"> 
+                                                        <td colspan="2">
+                                                            <div class="taxopress-group-wrap autoterm-tab-group when">
+                                                                <div class="taxopress-button-group">
+
+                                                                    <label class="post current">
+                                                                        <input disabled type="checkbox" name="taxopress_autoterm[autoterm_source_when_to_use_tab][]" value="post"><?php esc_html_e('Post', 'simple-tags'); ?></label>
+                                                                    <label class="schedule">
+                                                                        <input disabled type="checkbox" name="taxopress_autoterm[autoterm_source_when_to_use_tab][]" value="schedule"><?php esc_html_e('Schedule', 'simple-tags'); ?></label>
+                                                                    <label class="existing-content">
+                                                                        <input disabled type="checkbox" name="taxopress_autoterm[autoterm_source_when_to_use_tab][]" value="existing_content"><?php esc_html_e('Existing Content', 'simple-tags'); ?></label>
+                                                                    <label class="metaboxes">
+                                                                        <input disabled type="checkbox" name="taxopress_autoterm[autoterm_source_when_to_use_tab][]" value="metaboxes"><?php esc_html_e('Metaboxes', 'simple-tags'); ?></label>
+                                                                </div>
+                                                            </div>
+                                                        </td>
+                                                    </tr>
+                                                    <?php 
+                                                    
+                                                    if($autoterm_edit){
+                                                        $default_select             = [
+                                                            'options' => [
+                                                                [
+                                                                    'attr'    => '0',
+                                                                    'text'    => esc_attr__('False', 'simple-tags'),
+                                                                    'default' => 'true',
+                                                                ],
+                                                                [
+                                                                    'attr' => '1',
+                                                                    'text' => esc_attr__('True', 'simple-tags'),
+                                                                ],
+                                                            ],
+                                                        ];
+                                                    }else{
+                                                        $default_select             = [
+                                                            'options' => [
+                                                                [
+                                                                    'attr'    => '0',
+                                                                    'text'    => esc_attr__('False', 'simple-tags'),
+                                                                ],
+                                                                [
+                                                                    'attr' => '1',
+                                                                    'text' => esc_attr__('True', 'simple-tags'),
+                                                                    'default' => 'true',
+                                                                ],
+                                                            ],
+                                                        ];
+    
+                                                    }
+
+                                                    /**
+                                                     * Post
+                                                     */
+                                                    $selected           = (isset($current) && isset($current['autoterm_for_post'])) ? taxopress_disp_boolean($current['autoterm_for_post']) : '';
+                                                    $default_select['selected'] = !empty($selected) ? $current['autoterm_for_post'] : '';
+                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    echo $ui->get_select_checkbox_input([
+                                                        'namearray'  => 'taxopress_autoterm',
+                                                        'name'       => 'autoterm_for_post',
+                                                        'class'      => 'autoterm_for_post autoterm-terms-when-to-field autoterm-terms-when-post fields-control',
+                                                        'labeltext'  => esc_html__('Post', 'simple-tags'),
+                                                        'aftertext'  => esc_html__('Enable Auto Terms when a Post is Saved or Updated.', 'simple-tags'),
+                                                        'selections' => $default_select,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                        'required'    => false,
+                                                    ]);
+                                                    
+                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    echo $ui->get_number_input([
+                                                        'namearray' => 'taxopress_autoterm',
+                                                        'name'      => 'terms_limit',
+                                                        'textvalue' => isset($current['terms_limit']) ? esc_attr($current['terms_limit']) : '5',
+                                                        'class'      => 'autoterm_for_post autoterm-terms-when-to-field autoterm-terms-when-post',
+                                                        'labeltext' => esc_html__('Auto Terms Limit',
+                                                            'simple-tags'),
+                                                        'helptext'  => esc_html__('Limit the number of generated Auto Terms. \'0\' for unlimited terms', 'simple-tags'),
+                                                        'min'       => '0',
+                                                        'required'  => false,
+                                                    ]);
+
+                                                    
+                                                    $selected           = (isset($current) && isset($current['autoterm_target'])) ? taxopress_disp_boolean($current['autoterm_target']) : '';
+                                                    $default_select['selected'] = !empty($selected) ? $current['autoterm_target'] : '';
+                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    echo $ui->get_select_checkbox_input([
+                                                        'namearray'  => 'taxopress_autoterm',
+                                                        'name'       => 'autoterm_target',
+                                                        'class'      => 'autoterm_for_post autoterm-terms-when-to-field autoterm-terms-when-post',
+                                                        'labeltext'  => esc_html__('Target content', 'simple-tags'),
+                                                        'aftertext'  => esc_html__('Only use Auto Terms on posts with no added terms.', 'simple-tags'),
+                                                        'selections' => $default_select,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    ]);
+
+                                                    
+                                                    $selected           = (isset($current) && isset($current['autoterm_word'])) ? taxopress_disp_boolean($current['autoterm_word']) : '';
+                                                    $default_select['selected'] = !empty($selected) ? $current['autoterm_word'] : '';
+                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    echo $ui->get_select_checkbox_input([
+                                                        'namearray'  => 'taxopress_autoterm',
+                                                        'name'       => 'autoterm_word',
+                                                        'class'      => 'autoterm_for_post autoterm-terms-when-to-field autoterm-terms-when-post',
+                                                        'labeltext'  => esc_html__('Whole words', 'simple-tags'),
+                                                        'aftertext'  => esc_html__('Only add terms when the word is an exact match. Do not make matches for partial words.', 'simple-tags'),
+                                                        'selections' => $default_select,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    ]);
+
+                                                    
+                                                    $selected           = (isset($current) && isset($current['autoterm_hash'])) ? taxopress_disp_boolean($current['autoterm_hash']) : '';
+                                                    $default_select['selected'] = !empty($selected) ? $current['autoterm_hash'] : '';
+                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    echo $ui->get_select_checkbox_input([
+                                                        'namearray'  => 'taxopress_autoterm',
+                                                        'name'       => 'autoterm_hash',
+                                                        'class'      => 'autoterm_for_post autoterm-terms-when-to-field autoterm-terms-when-post',
+                                                        'labeltext'  => esc_html__('Hashtags', 'simple-tags'),
+                                                        'aftertext'  => esc_html__('Support hashtags symbols # in Auto Terms.', 'simple-tags'),
+                                                        'selections' => $default_select,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    ]);
+
+
+                                                    /**
+                                                     * Schedule
+                                                     */
+                                                    $selected           = (isset($current) && isset($current['autoterm_for_schedule'])) ? taxopress_disp_boolean($current['autoterm_for_schedule']) : '';
+                                                    $default_select['selected'] = !empty($selected) ? $current['autoterm_for_schedule'] : '';
+                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    echo $ui->get_select_checkbox_input([
+                                                        'namearray'  => 'taxopress_autoterm',
+                                                        'name'       => 'autoterm_for_schedule',
+                                                        'class'      => 'autoterm_for_schedule autoterm-terms-when-to-field autoterm-terms-when-schedule fields-control',
+                                                        'labeltext'  => esc_html__('Schedule', 'simple-tags'),
+                                                        'aftertext'  => esc_html__('Enable Auto Term Schedule.', 'simple-tags'),
+                                                        'selections' => $default_select,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                        'required'    => false,
+                                                    ]);
+                                                    
+                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    echo $ui->get_number_input([
+                                                        'namearray' => 'taxopress_autoterm',
+                                                        'name'      => 'schedule_terms_limit',
+                                                        'textvalue' => isset($current['schedule_terms_limit']) ? esc_attr($current['schedule_terms_limit']) : '5',
+                                                        'class'      => 'autoterm_for_schedule autoterm-terms-when-to-field autoterm-terms-when-schedule',
+                                                        'labeltext' => esc_html__('Auto Terms Limit',
+                                                            'simple-tags'),
+                                                        'helptext'  => esc_html__('Limit the number of generated Auto Terms. \'0\' for unlimited terms', 'simple-tags'),
+                                                        'min'       => '0',
+                                                        'required'  => false,
+                                                    ]);
+
+                                                    
+                                                    $selected           = (isset($current) && isset($current['schedule_autoterm_target'])) ? taxopress_disp_boolean($current['schedule_autoterm_target']) : '';
+                                                    $default_select['selected'] = !empty($selected) ? $current['schedule_autoterm_target'] : '';
+                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    echo $ui->get_select_checkbox_input([
+                                                        'namearray'  => 'taxopress_autoterm',
+                                                        'name'       => 'schedule_autoterm_target',
+                                                        'class'      => 'autoterm_for_schedule autoterm-terms-when-to-field autoterm-terms-when-schedule',
+                                                        'labeltext'  => esc_html__('Target content', 'simple-tags'),
+                                                        'aftertext'  => esc_html__('Only use Auto Terms on schedules with no added terms.', 'simple-tags'),
+                                                        'selections' => $default_select,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    ]);
+
+                                                    
+                                                    $selected           = (isset($current) && isset($current['schedule_autoterm_word'])) ? taxopress_disp_boolean($current['schedule_autoterm_word']) : '';
+                                                    $default_select['selected'] = !empty($selected) ? $current['schedule_autoterm_word'] : '';
+                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    echo $ui->get_select_checkbox_input([
+                                                        'namearray'  => 'taxopress_autoterm',
+                                                        'name'       => 'schedule_autoterm_word',
+                                                        'class'      => 'autoterm_for_schedule autoterm-terms-when-to-field autoterm-terms-when-schedule',
+                                                        'labeltext'  => esc_html__('Whole words', 'simple-tags'),
+                                                        'aftertext'  => esc_html__('Only add terms when the word is an exact match. Do not make matches for partial words.', 'simple-tags'),
+                                                        'selections' => $default_select,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    ]);
+
+                                                    
+                                                    $selected           = (isset($current) && isset($current['schedule_autoterm_hash'])) ? taxopress_disp_boolean($current['schedule_autoterm_hash']) : '';
+                                                    $default_select['selected'] = !empty($selected) ? $current['schedule_autoterm_hash'] : '';
+                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    echo $ui->get_select_checkbox_input([
+                                                        'namearray'  => 'taxopress_autoterm',
+                                                        'name'       => 'schedule_autoterm_hash',
+                                                        'class'      => 'autoterm_for_schedule autoterm-terms-when-to-field autoterm-terms-when-schedule',
+                                                        'labeltext'  => esc_html__('Hashtags', 'simple-tags'),
+                                                        'aftertext'  => esc_html__('Support hashtags symbols # in Auto Terms.', 'simple-tags'),
+                                                        'selections' => $default_select,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    ]);
+
+                                                    /**
+                                                     * Existing Content
+                                                     */
+                                                    $selected           = (isset($current) && isset($current['autoterm_for_existing_content'])) ? taxopress_disp_boolean($current['autoterm_for_existing_content']) : '';
+                                                    $default_select['selected'] = !empty($selected) ? $current['autoterm_for_existing_content'] : '';
+                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    echo $ui->get_select_checkbox_input([
+                                                        'namearray'  => 'taxopress_autoterm',
+                                                        'name'       => 'autoterm_for_existing_content',
+                                                        'class'      => 'autoterm_for_existing_content autoterm-terms-when-to-field autoterm-terms-when-existing-content fields-control',
+                                                        'labeltext'  => esc_html__('Existing Content', 'simple-tags'),
+                                                        'aftertext'  => esc_html__('Enable Auto Term for Existing Content.', 'simple-tags'),
+                                                        'selections' => $default_select,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                        'required'    => false,
+                                                    ]);
+
+
+                                                    /**
+                                                     * Metaboxes
+                                                     */
+                                                    $selected           = (isset($current) && isset($current['autoterm_for_metaboxes'])) ? taxopress_disp_boolean($current['autoterm_for_metaboxes']) : '';
+                                                    $default_select['selected'] = !empty($selected) ? $current['autoterm_for_metaboxes'] : '';
+                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    echo $ui->get_select_checkbox_input([
+                                                        'namearray'  => 'taxopress_autoterm',
+                                                        'name'       => 'autoterm_for_metaboxes',
+                                                        'class'      => 'autoterm_for_metaboxes autoterm-terms-when-to-field autoterm-terms-when-metaboxes fields-control',
+                                                        'labeltext'  => esc_html__('Metaboxes', 'simple-tags'),
+                                                        'aftertext'  => esc_html__('Enable Auto Term for Metaboxes.', 'simple-tags'),
+                                                        'selections' => $default_select,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                        'required'    => false,
+                                                    ]);
+                                                ?>
+                                                </table>
+
+
+
 
                                                 <table class="form-table taxopress-table autoterm_terms"
                                                        style="<?php echo $active_tab === 'autoterm_terms' ? '' : 'display:none;'; ?>">
                                                     <tr valign="top" class="tab-group-tr"> 
                                                         <td colspan="2">
-                                                            <div class="taxopress-group-wrap autoterm-tab-group">
+                                                            <div class="taxopress-group-wrap autoterm-tab-group source">
                                                                 <div class="taxopress-button-group">
                                                                     <label class="existing current">
                                                                         <input disabled type="checkbox" name="taxopress_autoterm[autoterm_source_tab][]" value="existing_terms"><?php esc_html_e('Existing Terms', 'simple-tags'); ?></label>
@@ -898,93 +1129,6 @@ class SimpleTags_Autoterms
                                                         ]);
                                                     }
                                                     
-                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                                                    echo $ui->get_number_input([
-                                                        'namearray' => 'taxopress_autoterm',
-                                                        'name'      => 'terms_limit',
-                                                        'textvalue' => isset($current['terms_limit']) ? esc_attr($current['terms_limit']) : '5',
-                                                        'labeltext' => esc_html__('Auto Terms Limit',
-                                                            'simple-tags'),
-                                                        'helptext'  => esc_html__('Limit the number of generated Auto Terms. \'0\' for unlimited terms', 'simple-tags'),
-                                                        'min'       => '0',
-                                                        'required'  => false,
-                                                    ]);
-
-
-                                                    $select             = [
-                                                        'options' => [
-                                                            [
-                                                                'attr'    => '0',
-                                                                'text'    => esc_attr__('False', 'simple-tags'),
-                                                                'default' => 'true',
-                                                            ],
-                                                            [
-                                                                'attr' => '1',
-                                                                'text' => esc_attr__('True', 'simple-tags'),
-                                                            ],
-                                                        ],
-                                                    ];
-                                                    $selected           = (isset($current) && isset($current['autoterm_target'])) ? taxopress_disp_boolean($current['autoterm_target']) : '';
-                                                    $select['selected'] = !empty($selected) ? $current['autoterm_target'] : '';
-                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                                                    echo $ui->get_select_checkbox_input([
-                                                        'namearray'  => 'taxopress_autoterm',
-                                                        'name'       => 'autoterm_target',
-                                                        'class'      => '',
-                                                        'labeltext'  => esc_html__('Target content', 'simple-tags'),
-                                                        'aftertext'  => esc_html__('Only use Auto Terms on posts with no added terms.', 'simple-tags'),
-                                                        'selections' => $select,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                                                    ]);
-
-                                                    $select             = [
-                                                        'options' => [
-                                                            [
-                                                                'attr'    => '0',
-                                                                'text'    => esc_attr__('False', 'simple-tags'),
-                                                                'default' => 'true',
-                                                            ],
-                                                            [
-                                                                'attr' => '1',
-                                                                'text' => esc_attr__('True', 'simple-tags'),
-                                                            ],
-                                                        ],
-                                                    ];
-                                                    $selected           = (isset($current) && isset($current['autoterm_word'])) ? taxopress_disp_boolean($current['autoterm_word']) : '';
-                                                    $select['selected'] = !empty($selected) ? $current['autoterm_word'] : '';
-                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                                                    echo $ui->get_select_checkbox_input([
-                                                        'namearray'  => 'taxopress_autoterm',
-                                                        'name'       => 'autoterm_word',
-                                                        'class'      => '',
-                                                        'labeltext'  => esc_html__('Whole words', 'simple-tags'),
-                                                        'aftertext'  => esc_html__('Only add terms when the word is an exact match. Do not make matches for partial words.', 'simple-tags'),
-                                                        'selections' => $select,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                                                    ]);
-
-                                                    $select             = [
-                                                        'options' => [
-                                                            [
-                                                                'attr'    => '0',
-                                                                'text'    => esc_attr__('False', 'simple-tags'),
-                                                                'default' => 'true',
-                                                            ],
-                                                            [
-                                                                'attr' => '1',
-                                                                'text' => esc_attr__('True', 'simple-tags'),
-                                                            ],
-                                                        ],
-                                                    ];
-                                                    $selected           = (isset($current) && isset($current['autoterm_hash'])) ? taxopress_disp_boolean($current['autoterm_hash']) : '';
-                                                    $select['selected'] = !empty($selected) ? $current['autoterm_hash'] : '';
-                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                                                    echo $ui->get_select_checkbox_input([
-                                                        'namearray'  => 'taxopress_autoterm',
-                                                        'name'       => 'autoterm_hash',
-                                                        'class'      => '',
-                                                        'labeltext'  => esc_html__('Hashtags', 'simple-tags'),
-                                                        'aftertext'  => esc_html__('Support hashtags symbols # in Auto Terms.', 'simple-tags'),
-                                                        'selections' => $select,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                                                    ]);
 
                                                     $post_status_objects = taxopress_get_post_statuses();
                                                     $post_status_options = [];

--- a/inc/class.admin.php
+++ b/inc/class.admin.php
@@ -1135,6 +1135,25 @@ class SimpleTags_Admin
 			SimpleTags_Plugin::set_option($options);
 
 			update_option('taxopress_3_23_0_upgrade_completed', true);
+		} elseif (!get_option('taxopress_3_28_0_upgrade_completed')) {
+
+			if (function_exists('taxopress_get_autoterm_data')) {
+				$autoterms      = taxopress_get_autoterm_data();
+				foreach ($autoterms as $autoterm_index => $autoterm) {
+					//enable when to fields
+					$autoterms[$autoterm_index]['autoterm_for_post'] = 1;
+					$autoterms[$autoterm_index]['autoterm_for_schedule'] = 1;
+					$autoterms[$autoterm_index]['autoterm_for_existing_content'] = 1;
+					$autoterms[$autoterm_index]['autoterm_for_metaboxes'] = 1;
+					// update new cloned fields for other groups
+					$autoterms[$autoterm_index]['schedule_terms_limit'] = !empty($autoterm['terms_limit']) ? $autoterm['terms_limit'] : 5;
+					$autoterms[$autoterm_index]['schedule_autoterm_target'] = !empty($autoterm['autoterm_target']) ? $autoterm['autoterm_target'] : 0;
+					$autoterms[$autoterm_index]['schedule_autoterm_word'] = !empty($autoterm['autoterm_word']) ? $autoterm['autoterm_word'] : 0;
+					$autoterms[$autoterm_index]['schedule_autoterm_hash'] = !empty($autoterm['autoterm_hash']) ? $autoterm['autoterm_hash'] : 0;
+				}
+				update_option('taxopress_autoterms', $autoterms);
+			}
+			update_option('taxopress_3_28_0_upgrade_completed', true);
 		}
 	}
 

--- a/inc/class.client.autoterms.php
+++ b/inc/class.client.autoterms.php
@@ -64,6 +64,10 @@ class SimpleTags_Client_Autoterms
 			if (!in_array($current_post_status, $eligible_post_status)) {
 				continue;
 			}
+			// check if auto term is enabled for post
+			if (empty($autoterm_data['autoterm_for_post'])) {
+				continue;
+			}	
 
 			self::auto_terms_post($object, $autoterm_data['taxonomy'], $autoterm_data, false, 'save_posts', 'st_autoterms');
 			$flag = true;

--- a/modules/taxopress-ai/classes/TaxoPressAiAjax.php
+++ b/modules/taxopress-ai/classes/TaxoPressAiAjax.php
@@ -206,6 +206,9 @@ if (!class_exists('TaxoPressAiAjax')) {
                     ) {
                         $response['status'] = 'error';
                         $response['content'] = esc_html__('You must enable at least one AI integration source to use auto term preview.', 'simple-tags');
+                    } elseif (empty($settings_data['autoterm_for_metaboxes'])) {
+                        $response['status'] = 'error';
+                        $response['content'] = esc_html__('The selected Auto Term is not enabled for metaboxes. Please enable it in Auto Term settings.', 'simple-tags');
                     } else {
                         $request_args  = $args;
                         $request_args['settings_data'] = $settings_data;


### PR DESCRIPTION
Add a new tab "When to Use", and move applicable settings to each subtabs #2200

fix https://github.com/TaxoPress/TaxoPress/issues/2200
fix https://github.com/TaxoPress/TaxoPress/issues/2346