### PR TITLE
update/#1910-Auto-Terms-allow-users-to-remove-existing-terms-when-adding-new-terms

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -102,6 +102,10 @@ table.st-autoterm-area-table .find-in-customs-row .action-checkbox {
     display: none !important;
 }
 
+.taxopress-radio-input {
+    margin-bottom: 10px;
+}
+
 .autoterm-description-tr td {
     padding: 0;
 }

--- a/inc/ajax-request.php
+++ b/inc/ajax-request.php
@@ -64,6 +64,7 @@ function taxopress_autoterms_content_by_ajax()
                 $autoterm_data['existing_terms_sleep'] = $existing_terms_sleep;
                 $autoterm_data['limit_days'] = $limit_days;
                 $autoterm_data['autoterm_exclude'] = $autoterm_existing_content_exclude;
+                $autoterm_data['replace_type'] = isset($autoterm_data['existing_content_replace_type']) ? $autoterm_data['existing_content_replace_type'] : '';
         }else{
             $response['message'] = '<div class="taxopress-response-css red"><p>'. esc_html__('Auto term settings not found', 'simple-tags') .'</p><button type="button" class="notice-dismiss"></button></div>';
             wp_send_json($response);

--- a/inc/autoterms.php
+++ b/inc/autoterms.php
@@ -335,6 +335,24 @@ class SimpleTags_Autoterms
 
 
         $ui = new taxopress_admin_ui();
+
+        $taxonomy_replace_options = [
+            'options' => [
+                [
+                    'attr' => 'append',
+                    'text' => esc_attr__('Append new terms to old terms.', 'simple-tags'),
+                    'default' => 'true'
+                ],
+                [
+                    'attr' => 'append_and_replace',
+                    'text' => esc_attr__('Add new terms and remove old terms.', 'simple-tags')
+                ],
+                [
+                    'attr' => 'replace',
+                    'text' => esc_attr__('Replace and remove old terms even if no new terms are found.', 'simple-tags')
+                ]
+            ],
+        ];
         ?>
 
 
@@ -830,6 +848,19 @@ class SimpleTags_Autoterms
                                                         'selections' => $default_select,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
                                                     ]);
 
+                                                    $selected   = (isset($current) && isset($current['post_replace_type'])) ? taxopress_disp_boolean($current['post_replace_type']) : '';
+                                                    $taxonomy_replace_options['selected'] = !empty($selected) ? $current['post_replace_type'] : '';
+                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    echo $ui->get_radio_input([
+                                                        'namearray'  => 'taxopress_autoterm',
+                                                        'name'       => 'post_replace_type',
+                                                        'class'      => 'autoterm_for_post autoterm-terms-when-to-field autoterm-terms-when-post',
+                                                        'labeltext'  => esc_html__('Auto Terms replace settings',
+                                                            'simple-tags'),
+                                                            'aftertext'  => esc_html__('This option determines what happens when adding new terms to posts.', 'simple-tags'),
+                                                        'selections' => $taxonomy_replace_options,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    ]);
+
 
                                                     /**
                                                      * Schedule
@@ -899,6 +930,19 @@ class SimpleTags_Autoterms
                                                         'selections' => $default_select,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
                                                     ]);
 
+                                                    $selected   = (isset($current) && isset($current['schedule_replace_type'])) ? taxopress_disp_boolean($current['schedule_replace_type']) : '';
+                                                    $taxonomy_replace_options['selected'] = !empty($selected) ? $current['schedule_replace_type'] : '';
+                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    echo $ui->get_radio_input([
+                                                        'namearray'  => 'taxopress_autoterm',
+                                                        'name'       => 'schedule_replace_type',
+                                                        'class'      => 'autoterm_for_schedule autoterm-terms-when-to-field autoterm-terms-when-schedule',
+                                                        'labeltext'  => esc_html__('Auto Terms replace settings',
+                                                            'simple-tags'),
+                                                            'aftertext'  => esc_html__('This option determines what happens when adding new terms to posts.', 'simple-tags'),
+                                                        'selections' => $taxonomy_replace_options,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    ]);
+
                                                     /**
                                                      * Existing Content
                                                      */
@@ -913,6 +957,19 @@ class SimpleTags_Autoterms
                                                         'aftertext'  => esc_html__('Enable Auto Term for Existing Content.', 'simple-tags'),
                                                         'selections' => $default_select,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
                                                         'required'    => false,
+                                                    ]);
+
+                                                    $selected   = (isset($current) && isset($current['existing_content_replace_type'])) ? taxopress_disp_boolean($current['existing_content_replace_type']) : '';
+                                                    $taxonomy_replace_options['selected'] = !empty($selected) ? $current['existing_content_replace_type'] : '';
+                                                    // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                                                    echo $ui->get_radio_input([
+                                                        'namearray'  => 'taxopress_autoterm',
+                                                        'name'       => 'existing_content_replace_type',
+                                                        'class'      => 'autoterm_for_existing_content autoterm-terms-when-to-field autoterm-terms-when-existing-content',
+                                                        'labeltext'  => esc_html__('Auto Terms replace settings',
+                                                            'simple-tags'),
+                                                            'aftertext'  => esc_html__('This option determines what happens when adding new terms to posts.', 'simple-tags'),
+                                                        'selections' => $taxonomy_replace_options,// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
                                                     ]);
 
 

--- a/inc/class.admin.taxonomies.ui.php
+++ b/inc/class.admin.taxonomies.ui.php
@@ -167,6 +167,70 @@ class taxopress_admin_ui
     }
 
     /**
+     * Return a populated `radio` input.
+     *
+     * @param array $args Arguments to use with the `radio` input.
+     * @return string $value Complete radio input with options and selected attribute.
+     */
+    public function get_radio_input($args = [])
+    {
+        $defaults = $this->get_default_input_parameters(
+            [
+                'class'    => '',
+                'selections' => []
+                ]
+        );
+
+        
+        $args = wp_parse_args($args, $defaults);
+
+        $value = '';
+        if ($args['wrap']) {
+            $value = $this->get_tr_start();
+            $value .= $this->get_th_start();
+            $value .= $this->get_label($args['name'], $args['labeltext']);
+            if ($args['required']) {
+                $value .= $this->get_required_span();
+            }
+            if (!empty($args['helptext'])) {
+                $value .= $this->get_help($args['helptext']);
+            }
+            $value .= $this->get_th_end();
+            $value .= $this->get_td_start();
+        }
+
+        $radio_html = '';
+
+        if (!empty($args['selections']['options']) && is_array($args['selections']['options'])) {
+            if (isset($args['selections']['selected']) && $args['selections']['selected'] !== '') {
+                $selected_option = $args['selections']['selected'];
+            } else {
+                $selected_option = '';
+            }
+            foreach ($args['selections']['options'] as $val) {
+                $checked = '';
+                if (($selected_option == '' && !empty($val['default']) && $val['default'] == 'true') || ($selected_option !== '' && $selected_option == $val['attr'])) {
+                    $checked = 'checked="checked"';
+                }
+                
+                $radio_html .= '<div class="taxopress-radio-input"><label> <input class="' . $args['class'] . '" type="radio" id="' . $args['name'] . '-' . $val['attr'] . '" name="' . $args['namearray'] . '[' . $args['name'] . ']" value="' . $val['attr'] . '" ' . $checked . ' />' . $val['text'] . '</label></div>';
+            }
+        }
+        $value .= $radio_html;
+
+        if (!empty($args['aftertext'])) {
+            $value .= '<p class="taxopress-field-description description">' . $args['aftertext'] . '</p>';
+        }
+
+        if ($args['wrap']) {
+            $value .= $this->get_td_end();
+            $value .= $this->get_tr_end();
+        }
+
+        return $value;
+    }
+
+    /**
      * Return a populated `<select>` input.
      *
      * @param array $args Arguments to use with the `<select>` input.


### PR DESCRIPTION
Auto Terms: allow users to remove existing terms when adding new terms fix #1910