### PR TITLE
update/#2440-Add-a-configuration-link-on-Metabox-description

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -13,6 +13,7 @@ class RoboFile extends \PublishPressBuilder\PackageBuilderTasks
         $this->setVersionConstantName('STAGS_VERSION');
         $this->appendToFileToIgnore(
             [
+                'dist',
                 '.phplint.yml',
                 'webpack.config.js',
                 'vendor/pimple/pimple/.gitignore',

--- a/modules/taxopress-ai/taxopress-ai.php
+++ b/modules/taxopress-ai/taxopress-ai.php
@@ -305,7 +305,7 @@ if (!class_exists('TaxoPress_AI_Module')) {
                     <?php echo esc_html__('Metaboxes', 'simple-tags'); ?>
                 </h1>
                 <div class="taxopress-description">
-                    <?php esc_html_e('This screen allows you to preview the TaxoPress features that users will see when creating and editing content.', 'simple-tags'); ?>
+                    <?php esc_html_e('This screen allows you to preview the TaxoPress features that users will see when creating and editing content.', 'simple-tags'); ?> <a target="_blank" href="<?php echo admin_url('admin.php?page=st_options#taxopress-ai') ?>"><?php echo esc_html__('Configure the metabox settings', 'simple-tags'); ?></a>.
                 </div>
                 <div class="wp-clearfix"></div>
                 <form method="post" action="">


### PR DESCRIPTION
Add a configuration link on Metabox description fix #2440