### PR TITLE
fix/#2427-TaxoPress-is-adding-menu-separator-with-wrong-filter 

### DIFF
--- a/inc/functions.inc.php
+++ b/inc/functions.inc.php
@@ -63,7 +63,7 @@ function taxopress_menu_separator($identifier, $parent) {
 /**
  * Change menu item order
  */
-add_action('custom_menu_order', 'taxopress_re_order_menu');
+add_action('admin_menu', 'taxopress_re_order_menu', 15);
 function taxopress_re_order_menu()
 {
     global $submenu;


### PR DESCRIPTION
TaxoPress is adding menu separator with wrong filter fix #2427