### PR TITLE
update/#2547-Add-button-to-delete-edited-taxonomies-data-from-TaxoPress

### DIFF
--- a/inc/taxonomies-functions.php
+++ b/inc/taxonomies-functions.php
@@ -129,6 +129,7 @@ function taxopress_delete_taxonomy($data = [])
     do_action('taxopress_before_delete_taxonomy', $data);
 
     $taxonomies = taxopress_get_taxonomy_data();
+    $external_taxonomies = taxopress_get_extername_taxonomy_data();
 
     if (array_key_exists(strtolower($data['cpt_custom_tax']['name']), $taxonomies)) {
 
@@ -143,6 +144,22 @@ function taxopress_delete_taxonomy($data = [])
          */
         if (false === ($success = apply_filters('taxopress_taxonomy_delete_tax', false, $taxonomies, $data))) {
             $success = update_option('taxopress_taxonomies', $taxonomies);
+        }
+    }
+
+    if (array_key_exists(strtolower($data['cpt_custom_tax']['name']), $external_taxonomies)) {
+
+        unset($external_taxonomies[$data['cpt_custom_tax']['name']]);
+
+        /**
+         * Filters whether or not 3rd party options were saved successfully within taxonomy deletion.
+         *
+         * @param bool $value Whether or not someone else saved successfully. Default false.
+         * @param array $external_taxonomies Array of our updated taxonomies data.
+         * @param array $data Array of submitted taxonomy to update.
+         */
+        if (false === ($success = apply_filters('taxopress_taxonomy_delete_tax', false, $external_taxonomies, $data))) {
+            $success = update_option('taxopress_external_taxonomies', $external_taxonomies);
         }
     }
 

--- a/inc/taxonomies.php
+++ b/inc/taxonomies.php
@@ -1577,8 +1577,14 @@ if ( isset($_GET['taxonomy_type']) && $_GET['taxonomy_type'] === 'all' ) {
                                            id="cpt_submit_delete"
                                            value="<?php echo esc_attr(apply_filters('taxopress_taxonomy_submit_delete',
                                                esc_html__('Delete Taxonomy', 'simple-tags'))); ?>"/>
-                                <?php }else{
-                                     echo '<div class="taxopress-warning" style="color:red;">' . esc_html__('You can only delete taxonomies created with TaxoPress.',
+                                <?php } else { ?>
+                                    <input type="submit" class="button-secondary taxopress-delete-bottom"
+                                           name="cpt_delete"
+                                           id="cpt_submit_delete"
+                                           value="<?php echo esc_attr(apply_filters('taxopress_taxonomy_submit_delete',
+                                               esc_html__('Delete TaxoPress Edit Data', 'simple-tags'))); ?>"/>
+                                    <?php
+                                     echo '<div class="taxopress-warning"">' . esc_html__('You can only delete taxonomies created with TaxoPress. However, you can delete any changes or edit made from TaxoPress which will remove TaxoPress version edit restoring original taxonomies data or removing it if already deleted',
                                     'simple-tags') . '</div>';
                                 }
                             }


### PR DESCRIPTION
Add button to delete edited taxonomies data from TaxoPress fix #2547