### PR TITLE
fix cant add 2 terms with the same name

### DIFF
--- a/inc/class.admin.php
+++ b/inc/class.admin.php
@@ -971,13 +971,40 @@ class SimpleTags_Admin
 			return '';
 		}
 
-		$terms = wp_get_post_terms($post_id, $taxonomy, array('fields' => 'names'));
-		if (empty($terms) || is_wp_error($terms)) {
-			return '';
-		}
+		$is_mass_edit_page = isset($_GET['page']) && $_GET['page'] === 'st_mass_terms';
+		$show_slug = SimpleTags_Plugin::get_option_value('enable_mass-edit_terms_slug');
+		
+		if ($is_mass_edit_page) {
+			$term_objects = wp_get_post_terms($post_id, $taxonomy);
+			if (empty($term_objects) || is_wp_error($term_objects)) {
+				return '';
+			}
+			
+			$terms = array();
+			foreach ($term_objects as $term) {
+				if ($show_slug) {
+					if (!empty($term->slug)) {
+						$terms[] = $term->name . ' (' . $term->slug . ')';
+					} else {
+						$terms[] = $term->name;
+					}
+				} else {
+					$terms[] = $term->name;
+				}
+			}
+			
+			$terms = join(', ', $terms);
+		} else {
 
-		$terms = array_unique($terms); // Remove duplicate
-		$terms = join(', ', $terms);
+            $terms = wp_get_post_terms($post_id, $taxonomy, array('fields' => 'names'));
+            if (empty($terms) || is_wp_error($terms)) {
+                return '';
+            }
+            
+            $terms = array_unique($terms);
+            $terms = join(', ', $terms);
+		}
+		
 		$terms = esc_attr($terms);
 		$terms = apply_filters('tags_to_edit', $terms);
 


### PR DESCRIPTION
adjusted how terms are handled to allow adding multiple terms with the same name but different slugs.

<!--
  Hey, that's awesome! Thanks for your interest and for taking the time to contribute.
  The following is a set of guidelines for contributing to PublishPress Authors plugin. Use your best judgment, and feel free to propose changes to this document in a pull request. 
  
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
  
  Please, review the guidelines for contributing to this repository:
  
  https://github.com/publishpress/PublishPress-Authors/blob/development/CONTRIBUTING.md
 -->

## Description
Can't add 2 terms with the same name #2826

## Benefits
fixed #2826 

## Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->

## Applicable issues
#2826 

## Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [x] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
