### PR TITLE
fix blank term screen by removing invalid parameters

### DIFF
--- a/inc/terms-table.php
+++ b/inc/terms-table.php
@@ -118,8 +118,33 @@ class Taxopress_Terms_List extends WP_List_Table
         $selected_post_type = (!empty($_REQUEST['terms_filter_post_type'])) ? [sanitize_text_field($_REQUEST['terms_filter_post_type'])] : '';
         $selected_taxonomy = (!empty($_REQUEST['terms_filter_taxonomy'])) ? sanitize_text_field($_REQUEST['terms_filter_taxonomy']) : '';
 
-        $order_setting = isset($taxonomy_settings[$selected_taxonomy]['order']) ? $taxonomy_settings[$selected_taxonomy]['order'] : 'desc';
+        $allowed_orderby = ['name', 'slug', 'taxonomy', 'count', 'id'];
+        $allowed_order   = ['asc', 'desc'];
+
+        $requested_orderby = !empty($_REQUEST['orderby']) ? sanitize_key($_REQUEST['orderby']) : '';
+        $requested_order   = !empty($_REQUEST['order'])   ? strtolower(sanitize_text_field($_REQUEST['order'])) : '';
+
+        if (!in_array($requested_orderby, $allowed_orderby, true)) {
+            $requested_orderby = '';
+        }
+        if (!in_array($requested_order, $allowed_order, true)) {
+            $requested_order = '';
+        }
+
+        $order_setting   = isset($taxonomy_settings[$selected_taxonomy]['order'])   ? strtolower($taxonomy_settings[$selected_taxonomy]['order'])   : 'desc';
         $orderby_setting = isset($taxonomy_settings[$selected_taxonomy]['orderby']) ? $taxonomy_settings[$selected_taxonomy]['orderby'] : 'ID';
+
+        $orderby_setting = strtolower($orderby_setting);
+        if ($orderby_setting === 'id' || $orderby_setting === 'term_id') {
+            $orderby_setting = 'id';
+        }
+
+        if ($requested_orderby) {
+            $orderby_setting = $requested_orderby;
+        }
+        if ($requested_order) {
+            $order_setting = $requested_order;
+        }
 
         // If viewing via taxopress_terms_taxonomy, override to show all terms in that taxonomy
         if (!empty($_REQUEST['taxopress_terms_taxonomy'])) {
@@ -138,6 +163,12 @@ class Taxopress_Terms_List extends WP_List_Table
         foreach ($taxonomies as $taxonomy) {
             $order_setting = isset($taxonomy_settings[$taxonomy]['order']) ? $taxonomy_settings[$taxonomy]['order'] : 'desc';
             $orderby_setting = isset($taxonomy_settings[$selected_taxonomy]['orderby']) ? $taxonomy_settings[$selected_taxonomy]['orderby'] : 'ID';
+            if ($requested_orderby) {
+                $orderby_setting = $requested_orderby;
+            }
+            if ($requested_order) {
+                $order_setting = $requested_order;
+            }
             if ($order_setting === 'taxopress_term_order') {
                 $manual_order = true;
                 break;
@@ -248,6 +279,13 @@ class Taxopress_Terms_List extends WP_List_Table
 
         if (empty($terms) || is_wp_error($terms)) {
             return [];
+        }
+
+        if (!empty($requested_orderby) && $requested_orderby === 'taxonomy') {
+            usort($terms, function ($a, $b) use ($order_setting) {
+                $cmp = strcmp($a->taxonomy, $b->taxonomy);
+                return ($order_setting === 'desc') ? -$cmp : $cmp;
+            });
         }
 
         if ($orderby_setting === 'random') {

--- a/inc/terms.php
+++ b/inc/terms.php
@@ -211,8 +211,11 @@ class SimpleTags_Terms
     public function page_manage_terms()
     {
         // Default order
+        if (!isset($_GET['orderby'])) {
+            $_GET['orderby'] = 'name';
+        }
         if (!isset($_GET['order'])) {
-            $_GET['order'] = 'name-asc';
+            $_GET['order'] = 'asc';
         }
 
         settings_errors(__CLASS__);


### PR DESCRIPTION
<!--
  Hey, that's awesome! Thanks for your interest and for taking the time to contribute.
  The following is a set of guidelines for contributing to PublishPress Authors plugin. Use your best judgment, and feel free to propose changes to this document in a pull request. 
  
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
  
  Please, review the guidelines for contributing to this repository:
  
  https://github.com/publishpress/PublishPress-Authors/blob/development/CONTRIBUTING.md
 -->

## Description
In newer WordPress 6.9, get_terms() / WP_Term_Query treats include strictly:
It must be an array of term IDs or a valid ID list, therefore passing 'all' is invalid and effectively makes the query look for term ID 0, which returns an empty result without a visible error.

Make Terms Table sortable by header clicks (count, name, slug)

## Benefits
fixed Terms screen is blank in 6.9 #2865

## Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->

## Applicable issues
#2865 

## Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [x] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
