### PR TITLE
Remove inline css added for autolinks

### DIFF
--- a/assets/frontend/css/frontend.css
+++ b/assets/frontend/css/frontend.css
@@ -164,3 +164,7 @@
     display: block;
     max-width: 100%;
 }
+
+a.st_tag, a.internal_tag, .st_tag, .internal_tag {
+    text-decoration: underline !important;
+}

--- a/inc/class.client.autolinks.php
+++ b/inc/class.client.autolinks.php
@@ -37,8 +37,6 @@ class SimpleTags_Client_Autolinks
                 add_filter('elementor/frontend/builder_content', array(__CLASS__, 'taxopress_autolinks_the_content'), 5);
             }
 
-            add_action('wp_head', [__CLASS__, 'print_autolink_inline_style']);
-
 			add_action('admin_init', [$this, 'taxopress_customurl_taxonomies_fields']);
 		}
 	}
@@ -89,11 +87,6 @@ class SimpleTags_Client_Autolinks
         }
 
         return $has_setting_saved ? array_unique($enabled_taxonomies) : $default_enabled_taxonomies;
-    }
-
-    public static function print_autolink_inline_style() {
-        // Ensure autolink anchors are visibly underlined on the frontend (overrides Elementor/theme rules)
-        echo '<style type="text/css">a.st_tag, a.internal_tag, .st_tag, .internal_tag { text-decoration: underline !important; }</style>';
     }
 
 	/**

--- a/inc/class.client.php
+++ b/inc/class.client.php
@@ -12,7 +12,7 @@ class SimpleTags_Client {
 		add_action( 'init', array( __CLASS__, 'init_translation' ) );
 
 		// Enqueue frontend scripts
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_displayformat_scripts' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_displayformat_scripts' ), 999 );
 
         require( STAGS_DIR . '/inc/class.client.autolinks.php' );
         new SimpleTags_Client_Autolinks();


### PR DESCRIPTION
Remove inline css added for autolinks
Adds High Priority to frontend css so it loads after elementor and others

<!--
  Hey, that's awesome! Thanks for your interest and for taking the time to contribute.
  The following is a set of guidelines for contributing to PublishPress Authors plugin. Use your best judgment, and feel free to propose changes to this document in a pull request. 
  
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
  
  Please, review the guidelines for contributing to this repository:
  
  https://github.com/publishpress/PublishPress-Authors/blob/development/CONTRIBUTING.md
 -->

## Description
Remove inline css added for autolinks

## Benefits
fix #2877 

## Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->

## Applicable issues
#2877 

## Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [x] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
