### PR TITLE
Fix TypeError: array_keys() null argument in term merge

### DIFF
--- a/inc/class.admin.manage.php
+++ b/inc/class.admin.manage.php
@@ -618,6 +618,8 @@ class SimpleTags_Admin_Manage
             }
 
             $counter = 0;
+            $unique_objects = [];
+            $terms_id = [];
             if (count($new_terms) == 1) { // Merge
                 // Set new tag
                 $new_tag = sanitize_text_field($new_terms[0]);
@@ -709,7 +711,9 @@ class SimpleTags_Admin_Manage
                 }
             } else { // Error
                 add_settings_error(__CLASS__, __CLASS__, sprintf(esc_html__('Error. You need to enter a single term to merge to in new term name !', 'simple-tags'), $old), 'error taxopress-notice');
-            }           
+                return false;
+            }
+            
             return [
                 'success' => true,
                 'merged_into' => $new_tag,


### PR DESCRIPTION
<!--
  Hey, that's awesome! Thanks for your interest and for taking the time to contribute.
  The following is a set of guidelines for contributing to PublishPress Authors plugin. Use your best judgment, and feel free to propose changes to this document in a pull request. 
  
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
  
  Please, review the guidelines for contributing to this repository:
  
  https://github.com/publishpress/PublishPress-Authors/blob/development/CONTRIBUTING.md
 -->

## Description
Uncaught TypeError: array_keys(): Argument #1 #2921
Fix TypeError: array_keys() null argument in term merge

Initialize variables before merge logic and return early on error to prevent null reference in array_keys() call.

## Benefits
fixed #2921

## Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->

## Applicable issues
#2921 

## Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [x] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
