### PR TITLE
Prevent serialized data in Auto Terms specific terms

### DIFF
--- a/inc/autoterms-functions.php
+++ b/inc/autoterms-functions.php
@@ -290,7 +290,7 @@ function taxopress_create_default_autoterm()
                     $default['taxopress_autoterm']['autoterm_target']          = isset($options_taxonomy_data['at_empty']) ? $options_taxonomy_data['at_empty'] : 0;
                     $default['taxopress_autoterm']['autoterm_word']            = isset($options_taxonomy_data['only_full_word']) ? $options_taxonomy_data['only_full_word'] : 0;
                     $default['taxopress_autoterm']['autoterm_hash']            = isset($options_taxonomy_data['allow_hashtag_format']) ? $options_taxonomy_data['allow_hashtag_format'] : 0;
-                    $default['specific_terms']            = isset($options_taxonomy_data['auto_list']) ? (array) maybe_unserialize($options_taxonomy_data['auto_list']) : [];
+                    $default['specific_terms']            = isset($options_taxonomy_data['auto_list']) ? taxopress_sanitize_specific_terms($options_taxonomy_data['auto_list']) : [];
                     $default['taxopress_autoterm']['terms_limit']              = '5';
                     $default['taxopress_autoterm']['synonyms_term']            = 1;
 
@@ -337,6 +337,42 @@ add_action('admin_init', 'taxopress_create_default_autoterm', 8);
 
 
 /**
+ * Normalize Auto Terms' specific-term setting without accepting serialized data.
+ *
+ * @param mixed $terms Specific terms from a request or saved option.
+ * @return array
+ */
+function taxopress_sanitize_specific_terms($terms)
+{
+    if (!is_array($terms)) {
+        if (!is_scalar($terms)) {
+            return [];
+        }
+
+        $terms = wp_unslash((string) $terms);
+        if (is_serialized($terms)) {
+            return [];
+        }
+
+        $terms = taxopress_change_to_array($terms);
+    }
+
+    $sanitized_terms = [];
+    foreach ($terms as $term) {
+        if (!is_scalar($term)) {
+            continue;
+        }
+
+        $term = sanitize_text_field(wp_unslash((string) $term));
+        if ($term !== '') {
+            $sanitized_terms[] = $term;
+        }
+    }
+
+    return array_values(array_unique($sanitized_terms));
+}
+
+/**
  * Add to or update our TAXOPRESS option with new data.
  *
  *
@@ -349,7 +385,9 @@ function taxopress_update_autoterm($data = [])
 {
     $sanitized_data = [];
     foreach ($data as $key => $value) {
-        if (!is_array($value)) {
+        if ($key === 'specific_terms') {
+            $sanitized_data[$key] = taxopress_sanitize_specific_terms($value);
+        } elseif (!is_array($value)) {
             $sanitized_data[$key] = taxopress_sanitize_text_field($value);
         } else {
             $new_value = [];

--- a/inc/class.client.autoterms.php
+++ b/inc/class.client.autoterms.php
@@ -593,8 +593,7 @@ class SimpleTags_Client_Autoterms
 
         if ($autoterm_use_taxonomy && $autoterm_useonly && !empty($options['specific_terms'])) {
             // Auto term with specific auto terms list
-            $terms = maybe_unserialize($options['specific_terms']);
-            $terms = taxopress_change_to_array($terms);
+            $terms = taxopress_sanitize_specific_terms($options['specific_terms']);
             foreach ($terms as $term) {
                 if (!is_string($term)) {
                     continue;


### PR DESCRIPTION
<!--
  Hey, that's awesome! Thanks for your interest and for taking the time to contribute.
  The following is a set of guidelines for contributing to PublishPress Authors plugin. Use your best judgment, and feel free to propose changes to this document in a pull request. 
  
  Filling out this template is required when contributing.
  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
  
  Please, review the guidelines for contributing to this repository:
  
  https://github.com/publishpress/PublishPress-Authors/blob/development/CONTRIBUTING.md
 -->

## Description
Add a dedicated normalizer for the specific_terms setting that accepts plain arrays or comma-separated text, sanitizes every term as a scalar text value, and rejects serialized scalar input.
Use the normalizer when saving, migrating, and processing Auto Terms configurations. 
Remove maybe_unserialize() from the active specific terms processing path to prevent saved values from instantiating PHP objects.

## Benefits
fix #3001 

## Possible drawbacks
<!-- What are the possible side-effects or negative impacts of the code changes? -->

## Applicable issues
#3001 
## Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have created a specific branch for this pull request before committing, starting off the current HEAD of `development` branch. 
- [x] I'm submitting to the `development`, feature/hotfix/release branch. (Do not submit to the master branch!)
- [x] This pull request relates to a specific problem (bug or improvement).
- [x] I have mentioned the issue number in the pull request description text.
- [x] All the issues mentioned in this pull request relate to the problem I'm trying to solve.
- [x] The code I'm sending follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) coding style.
